### PR TITLE
Add get_alphabet to zhfstospeller

### DIFF
--- a/ZHfstOspeller.cc
+++ b/ZHfstOspeller.cc
@@ -245,6 +245,17 @@ ZHfstOspeller::suggest_analyses(const string& wordform)
     return rv;
   }
 
+KeyTable*
+ZHfstOspeller::get_alphabet() const
+{
+    if (current_speller_ == nullptr)
+    {
+        return nullptr;
+    }
+
+    return current_speller_->lexicon->get_key_table();
+}
+
 void
 ZHfstOspeller::read_zhfst(const string& filename)
   {

--- a/ZHfstOspeller.h
+++ b/ZHfstOspeller.h
@@ -90,6 +90,9 @@ namespace hfst_ol
             //! @brief create string representation of the speller for
             //!        programmer to debug
             std::string metadata_dump() const;
+
+            //! @brief Alphabet for the current speller
+            KeyTable* get_alphabet() const;
         private:
             //! @brief file or path where the speller came from
             std::string filename_;


### PR DESCRIPTION
While implementing support for case handling in [divvun/hfst-ospell-js](https://github.com/divvun/hfst-ospell-js) I needed to get access to the alphabet provided by the current speller, and there was no public interface for doing so.

This pull request implements the given feature.
