### PR TITLE
Consistent application of code styling

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,0 +1,64 @@
+indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
+input_tab_size			= 4		# original tab size
+output_tab_size			= 4		# new tab size
+indent_columns			= output_tab_size
+
+# brace settings
+nl_assign_brace			= add		# "= {" vs "= \n {"
+nl_enum_brace			= add		# "enum {" vs "enum \n {"
+nl_union_brace			= add		# "union {" vs "union \n {"
+nl_struct_brace			= add		# "struct {" vs "struct \n {"
+nl_do_brace			= remove		# "do {" vs "do \n {"
+nl_if_brace			= remove		# "if () {" vs "if () \n {"
+nl_for_brace			= remove		# "for () {" vs "for () \n {"
+nl_else_brace			= remove		# "else {" vs "else \n {"
+nl_while_brace			= remove		# "while () {" vs "while () \n {"
+nl_switch_brace			= remove		# "switch () {" vs "switch () \n {"
+nl_fcall_brace			= add		# "foo() {" vs "foo()\n{"
+nl_fdef_brace			= add		# "int foo() {" vs "int foo()\n{"
+nl_brace_while			= remove
+nl_brace_else			= remove
+
+mod_add_long_ifdef_endif_comment          = 20
+mod_add_long_ifdef_else_comment           = mod_add_long_ifdef_else_comment
+mod_add_long_switch_closebrace_comment    = mod_add_long_ifdef_else_comment
+mod_add_long_function_closebrace_comment  = mod_add_long_ifdef_else_comment
+
+sp_after_semi_for = ignore
+sp_before_sparen             = force      # "if (" vs "if("
+sp_after_sparen              = force      # "if () {" vs "if (){"
+sp_after_cast                = force    # "(int) a" vs "(int)a"
+sp_inside_braces             = add     # "{ 1 }" vs "{1}"
+sp_inside_braces_struct      = add     # "{ 1 }" vs "{1}"
+sp_inside_braces_enum        = add     # "{ 1 }" vs "{1}"
+sp_inside_fparen             = remove    # "func( param )" vs "func(param)"
+sp_paren_brace               = force
+sp_assign                    = add
+sp_assign_default            = remove
+sp_arith                     = add
+sp_bool                      = add
+sp_compare                   = add
+sp_assign                    = add
+sp_after_comma               = add
+sp_func_def_paren            = remove  # "int foo (){" vs "int foo(){"
+sp_func_call_paren           = remove  # "foo (" vs "foo("
+sp_func_proto_paren          = remove  # "int foo ();" vs "int foo();"
+sp_after_ptr_star            = force
+sp_before_ptr_star           = remove
+sp_before_unnamed_ptr_star   = ignore
+sp_between_ptr_star          = remove
+sp_after_ptr_star_func       = force
+sp_before_ptr_star_func      = remove
+sp_cmt_cpp_start             = ignore
+sp_cond_question             = force
+sp_cond_colon                = force
+sp_else_brace                = force
+sp_brace_else                = force
+sp_after_class_colon         = force
+sp_before_class_colon        = force
+sp_before_case_colon         = remove
+
+cmt_star_cont                 = true     # Whether to put a star on subsequent comment lines
+indent_class = true
+indent_relative_single_line_comments = true
+indent_col1_comment = true

--- a/ZHfstOspeller.cc
+++ b/ZHfstOspeller.cc
@@ -38,62 +38,51 @@ using std::map;
 #include "ZHfstOspeller.h"
 
 namespace hfst_ol
-  {
+{
 
 #if HAVE_LIBARCHIVE
 #if ZHFST_EXTRACT_TO_MEM
 static
 char*
 extract_to_mem(archive* ar, archive_entry* entry, size_t* n)
-  {
+{
     size_t full_length = 0;
     const struct stat* st = archive_entry_stat(entry);
     size_t buffsize = st->st_size;
-    char * buff = new char[buffsize];
-    for (;;)
-      {
+    char* buff = new char[buffsize];
+    for (;;) {
         ssize_t curr = archive_read_data(ar, buff + full_length, buffsize - full_length);
-        if (0 == curr)
-          {
+        if (0 == curr) {
             break;
-          }
-        else if (ARCHIVE_RETRY == curr)
-          {
+        } else if (ARCHIVE_RETRY == curr) {
             continue;
-          }
-        else if (ARCHIVE_FAILED == curr)
-          {
+        } else if (ARCHIVE_FAILED == curr) {
             throw ZHfstZipReadingError("Archive broken (ARCHIVE_FAILED)");
-          }
-        else if (curr < 0)
-          {
+        } else if (curr < 0) {
             throw ZHfstZipReadingError("Archive broken...");
-          } 
-        else
-          {
+        } else {
             full_length += curr;
-          }
-      }
+        }
+    }
     *n = full_length;
     return buff;
-  }
-#endif
+}
+#endif // if ZHFST_EXTRACT_TO_MEM
 
 #if ZHFST_EXTRACT_TO_TMPDIR
 static
 char*
 extract_to_tmp_dir(archive* ar)
-  {
+{
     char* rv = strdup("/tmp/zhfstospellXXXXXXXX");
     int temp_fd = mkstemp(rv);
     int rr = archive_read_data_into_fd(ar, temp_fd);
-    if ((rr != ARCHIVE_EOF) && (rr != ARCHIVE_OK))
-      {
+    if ((rr != ARCHIVE_EOF) && (rr != ARCHIVE_OK)) {
         throw ZHfstZipReadingError("Archive not EOF'd or OK'd");
-      }
+    }
     close(temp_fd);
     return rv;
-  }
+}
 #endif
 
 #endif // HAVE_LIBARCHIVE
@@ -108,93 +97,85 @@ ZHfstOspeller::ZHfstOspeller() :
     can_analyse_(true),
     current_speller_(0),
     current_sugger_(0)
-    {
-    }
+{
+}
 
 ZHfstOspeller::~ZHfstOspeller()
-  {
-    if ((current_speller_ != NULL) && (current_sugger_ != NULL))
-      {
-        if (current_speller_ != current_sugger_)
-          {
+{
+    if ((current_speller_ != NULL) && (current_sugger_ != NULL)) {
+        if (current_speller_ != current_sugger_) {
             delete current_speller_;
             delete current_sugger_;
-          }
-        else
-          {
+        } else {
             delete current_speller_;
-          }
+        }
         current_sugger_ = 0;
         current_speller_ = 0;
-      }
+    }
     for (map<string, Transducer*>::iterator acceptor = acceptors_.begin();
          acceptor != acceptors_.end();
-         ++acceptor)
-      {
+         ++acceptor) {
         delete acceptor->second;
-      }
+    }
     for (map<string, Transducer*>::iterator errmodel = errmodels_.begin();
          errmodel != errmodels_.end();
-         ++errmodel)
-      {
+         ++errmodel) {
         delete errmodel->second;
-      }
+    }
     can_spell_ = false;
     can_correct_ = false;
-  }
+}
 
 void
-ZHfstOspeller::inject_speller(Speller * s)
-  {
-      current_speller_ = s;
-      current_sugger_ = s;
-      can_spell_ = true;
-      can_correct_ = true;
-  }
+ZHfstOspeller::inject_speller(Speller* s)
+{
+    current_speller_ = s;
+    current_sugger_ = s;
+    can_spell_ = true;
+    can_correct_ = true;
+}
 
 void
 ZHfstOspeller::set_queue_limit(unsigned long limit)
-  {
+{
     suggestions_maximum_ = limit;
-  }
+}
 
 void
 ZHfstOspeller::set_weight_limit(Weight limit)
-  {
+{
     maximum_weight_ = limit;
-  }
+}
 
 void
 ZHfstOspeller::set_beam(Weight beam)
-  {
-      beam_ = beam;
-  }
+{
+    beam_ = beam;
+}
 
 void
 ZHfstOspeller::set_time_cutoff(float time_cutoff)
-  {
-      time_cutoff_ = time_cutoff;
-  }
+{
+    time_cutoff_ = time_cutoff;
+}
 
 bool
 ZHfstOspeller::spell(const string& wordform)
-  {
-    if (can_spell_ && (current_speller_ != 0))
-      {
+{
+    if (can_spell_ && (current_speller_ != 0)) {
         char* wf = strdup(wordform.c_str());
         bool rv = current_speller_->check(wf);
         free(wf);
         return rv;
-      }
+    }
     return false;
-  }
+}
 
 CorrectionQueue
 ZHfstOspeller::suggest(const string& wordform)
-  {
+{
     CorrectionQueue rv;
-    if ((can_correct_) && (current_sugger_ != 0))
-      {
+    if ((can_correct_) && (current_sugger_ != 0)) {
         char* wf = strdup(wordform.c_str());
         rv = current_sugger_->correct(wf,
                                       suggestions_maximum_,
@@ -203,51 +184,46 @@ ZHfstOspeller::suggest(const string& wordform)
                                       time_cutoff_);
         free(wf);
         return rv;
-      }
+    }
     return rv;
-  }
+}
 
 AnalysisQueue
 ZHfstOspeller::analyse(const string& wordform, bool ask_sugger)
-  {
+{
     AnalysisQueue rv;
     char* wf = strdup(wordform.c_str());
-    if ((can_analyse_) && (!ask_sugger) && (current_speller_ != 0))
-      {
-          rv = current_speller_->analyse(wf);
-      }
-    else if ((can_analyse_) && (ask_sugger) && (current_sugger_ != 0))
-      {
-          rv = current_sugger_->analyse(wf);
-      }
+    if ((can_analyse_) && (!ask_sugger) && (current_speller_ != 0)) {
+        rv = current_speller_->analyse(wf);
+    } else if ((can_analyse_) && (ask_sugger) && (current_sugger_ != 0)) {
+        rv = current_sugger_->analyse(wf);
+    }
     free(wf);
     return rv;
-  }
+}
 
 AnalysisCorrectionQueue
 ZHfstOspeller::suggest_analyses(const string& wordform)
-  {
+{
     AnalysisCorrectionQueue rv;
     // FIXME: should be atomic
     CorrectionQueue cq = suggest(wordform);
-    while (cq.size() > 0)
-      {
+    while (cq.size() > 0) {
         AnalysisQueue aq = analyse(cq.top().first, true);
-        while (aq.size() > 0)
-          {
+        while (aq.size() > 0) {
             StringPair sp(cq.top().first, aq.top().first);
             StringPairWeightPair spwp(sp, aq.top().second);
             rv.push(spwp);
             aq.pop();
-          }
+        }
         cq.pop();
-      }
+    }
     return rv;
-  }
+}
 
 void
 ZHfstOspeller::read_zhfst(const string& filename)
-  {
+{
 #if HAVE_LIBARCHIVE
     struct archive* ar = archive_read_new();
     struct archive_entry* entry = 0;
@@ -260,21 +236,17 @@ ZHfstOspeller::read_zhfst(const string& filename)
 
     archive_read_support_format_all(ar);
     int rr = archive_read_open_filename(ar, filename.c_str(), 10240);
-    if (rr != ARCHIVE_OK)
-      {
+    if (rr != ARCHIVE_OK) {
         throw ZHfstZipReadingError("Archive not OK");
-      }
-    for (int rr = archive_read_next_header(ar, &entry); 
+    }
+    for (int rr = archive_read_next_header(ar, &entry);
          rr != ARCHIVE_EOF;
-         rr = archive_read_next_header(ar, &entry))
-      {
-        if (rr != ARCHIVE_OK)
-          {
+         rr = archive_read_next_header(ar, &entry)) {
+        if (rr != ARCHIVE_OK) {
             throw ZHfstZipReadingError("Archive not OK");
-          }
+        }
         char* filename = strdup(archive_entry_pathname(entry));
-        if (strncmp(filename, "acceptor.", strlen("acceptor.")) == 0)
-          {
+        if (strncmp(filename, "acceptor.", strlen("acceptor.")) == 0) {
 #if ZHFST_EXTRACT_TO_TMPDIR
             char* temporary = extract_to_tmp_dir(ar);
 #elif ZHFST_EXTRACT_TO_MEM
@@ -284,25 +256,20 @@ ZHfstOspeller::read_zhfst(const string& filename)
             char* p = filename;
             p += strlen("acceptor.");
             size_t descr_len = 0;
-            for (const char* q = p; *q != '\0'; q++)
-              {
-                if (*q == '.')
-                  {
+            for (const char* q = p; *q != '\0'; q++) {
+                if (*q == '.') {
                     break;
-                  }
-                else
-                    {
-                      descr_len++;
-                    }
-              }
+                } else {
+                    descr_len++;
+                }
+            }
             char* descr = hfst_strndup(p, descr_len);
 #if ZHFST_EXTRACT_TO_TMPDIR
             FILE* f = fopen(temporary, "r");
-            if (f == NULL)
-              {
-                  throw ZHfstTemporaryWritingError("reading acceptor back "
-                                                   "from temp file");
-              }
+            if (f == NULL) {
+                throw ZHfstTemporaryWritingError("reading acceptor back "
+                                                 "from temp file");
+            }
             Transducer* trans = new Transducer(f);
 #elif ZHFST_EXTRACT_TO_MEM
             Transducer* trans = new Transducer(full_data);
@@ -310,9 +277,7 @@ ZHfstOspeller::read_zhfst(const string& filename)
 #endif
             acceptors_[descr] = trans;
             free(descr);
-          }
-        else if (strncmp(filename, "errmodel.", strlen("errmodel.")) == 0)
-          {
+        } else if (strncmp(filename, "errmodel.", strlen("errmodel.")) == 0) {
 #if ZHFST_EXTRACT_TO_TMPDIR
             char* temporary = extract_to_tmp_dir(ar);
 #elif ZHFST_EXTRACT_TO_MEM
@@ -322,25 +287,20 @@ ZHfstOspeller::read_zhfst(const string& filename)
             const char* p = filename;
             p += strlen("errmodel.");
             size_t descr_len = 0;
-            for (const char* q = p; *q != '\0'; q++)
-              {
-                if (*q == '.')
-                  {
+            for (const char* q = p; *q != '\0'; q++) {
+                if (*q == '.') {
                     break;
-                  }
-                else
-                  {
+                } else {
                     descr_len++;
-                  }
-              }
+                }
+            }
             char* descr = hfst_strndup(p, descr_len);
 #if ZHFST_EXTRACT_TO_TMPDIR
             FILE* f = fopen(temporary, "r");
-            if (NULL == f)
-              {
+            if (NULL == f) {
                 throw ZHfstTemporaryWritingError("reading errmodel back "
                                                  "from temp file");
-              }
+            }
             Transducer* trans = new Transducer(f);
 #elif ZHFST_EXTRACT_TO_MEM
             Transducer* trans = new Transducer(full_data);
@@ -348,9 +308,8 @@ ZHfstOspeller::read_zhfst(const string& filename)
 #endif
             errmodels_[descr] = trans;
             free(descr);
-          } // if acceptor or errmodel
-        else if (strcmp(filename, "index.xml") == 0)
-          {
+        } // if acceptor or errmodel
+        else if (strcmp(filename, "index.xml") == 0) {
 #if ZHFST_EXTRACT_TO_TMPDIR
             char* temporary = extract_to_tmp_dir(ar);
             metadata_.read_xml(temporary);
@@ -361,13 +320,11 @@ ZHfstOspeller::read_zhfst(const string& filename)
             delete[] full_data;
 #endif
 
-          }
-        else
-          {
+        } else {
             fprintf(stderr, "Unknown file in archive %s\n", filename);
-          }
+        }
         free(filename);
-      } // while r != ARCHIVE_EOF
+    } // while r != ARCHIVE_EOF
     archive_read_close(ar);
 
 #if USE_LIBARCHIVE_2
@@ -377,96 +334,91 @@ ZHfstOspeller::read_zhfst(const string& filename)
 #endif // USE_LIBARCHIVE_2
 
     if ((errmodels_.find("default") != errmodels_.end()) &&
-        (acceptors_.find("default") != acceptors_.end()))
-      {
+        (acceptors_.find("default") != acceptors_.end())) {
         current_speller_ = new Speller(
-                                       errmodels_["default"],
-                                       acceptors_["default"]
-                                       );
+            errmodels_["default"],
+            acceptors_["default"]
+            );
         current_sugger_ = current_speller_;
         can_spell_ = true;
         can_correct_ = true;
-      }
-    else if ((acceptors_.size() > 0) && (errmodels_.size() > 0))
-      {
+    } else if ((acceptors_.size() > 0) && (errmodels_.size() > 0)) {
         fprintf(stderr, "Could not find default speller, using %s %s\n",
                 acceptors_.begin()->first.c_str(),
                 errmodels_.begin()->first.c_str());
         current_speller_ = new Speller(
-                                       errmodels_.begin()->second,
-                                       acceptors_.begin()->second
-                                       );
+            errmodels_.begin()->second,
+            acceptors_.begin()->second
+            );
         current_sugger_ = current_speller_;
         can_spell_ = true;
         can_correct_ = true;
-      }
-    else if ((acceptors_.size() > 0) && 
-             (acceptors_.find("default") != acceptors_.end()))
-      {
+    } else if ((acceptors_.size() > 0) &&
+               (acceptors_.find("default") != acceptors_.end())) {
         current_speller_ = new Speller(0, acceptors_["default"]);
         current_sugger_ = current_speller_;
         can_spell_ = true;
         can_correct_ = false;
-      }
-    else if (acceptors_.size() > 0)
-      {
+    } else if (acceptors_.size() > 0) {
         current_speller_ = new Speller(0, acceptors_.begin()->second);
         current_sugger_ = current_speller_;
         can_spell_ = true;
         can_correct_ = false;
-      }
-    else
-      {
+    } else {
         throw ZHfstZipReadingError("No automata found in zip");
-      }
+    }
     can_analyse_ = can_spell_ | can_correct_;
 #else
     throw ZHfstZipReadingError("Zip support was disabled");
 #endif // HAVE_LIBARCHIVE
-  }
+}
 
 
 const ZHfstOspellerXmlMetadata&
 ZHfstOspeller::get_metadata() const
-  {
+{
     return metadata_;
-  }
+}
 
 string
 ZHfstOspeller::metadata_dump() const
-  {
+{
     return metadata_.debug_dump();
 
-  }
+}
 
 ZHfstException::ZHfstException() :
     what_("unknown")
-    {}
+{
+}
 ZHfstException::ZHfstException(const std::string& message) :
     what_(message)
-      {}
+{
+}
 
 
-const char* 
+const char*
 ZHfstException::what()
-  {
+{
     return what_.c_str();
-  }
+}
 
 
-ZHfstMetaDataParsingError::ZHfstMetaDataParsingError(const std::string& message):
+ZHfstMetaDataParsingError::ZHfstMetaDataParsingError(const std::string& message) :
     ZHfstException(message)
-  {}
-ZHfstXmlParsingError::ZHfstXmlParsingError(const std::string& message):
+{
+}
+ZHfstXmlParsingError::ZHfstXmlParsingError(const std::string& message) :
     ZHfstException(message)
-  {}
-ZHfstZipReadingError::ZHfstZipReadingError(const std::string& message):
+{
+}
+ZHfstZipReadingError::ZHfstZipReadingError(const std::string& message) :
     ZHfstException(message)
-  {}
-ZHfstTemporaryWritingError::ZHfstTemporaryWritingError(const std::string& message):
+{
+}
+ZHfstTemporaryWritingError::ZHfstTemporaryWritingError(const std::string& message) :
     ZHfstException(message)
-    {}
- 
+{
+}
+
 } // namespace hfst_ol
-
-

--- a/ZHfstOspeller.h
+++ b/ZHfstOspeller.h
@@ -38,166 +38,166 @@
 #include "hfst-ol.h"
 #include "ZHfstOspellerXmlMetadata.h"
 
-namespace hfst_ol 
-  {
-    //! @brief ZHfstOspeller class holds one speller contained in one
-    //!        zhfst file.
-    //!        Ospeller can perform all basic writer tool functionality that
-    //!        is supporte by the automata in the zhfst archive.
-    class ZHfstOspeller
-      {
-        public:
-            //! @brief create speller with default values for undefined 
-            //!        language.
-            ZHfstOspeller();
-            //! @brief destroy all automata used by the speller.
-            ~ZHfstOspeller();
+namespace hfst_ol
+{
+//! @brief ZHfstOspeller class holds one speller contained in one
+//!        zhfst file.
+//!        Ospeller can perform all basic writer tool functionality that
+//!        is supporte by the automata in the zhfst archive.
+class ZHfstOspeller
+{
+public:
+    //! @brief create speller with default values for undefined
+    //!        language.
+    ZHfstOspeller();
+    //! @brief destroy all automata used by the speller.
+    ~ZHfstOspeller();
 
-            //! @brief assign a speller-suggestor circumventing the ZHFST format
-            void inject_speller(Speller * s);
-            //! @brief set upper limit to priority queue when performing
-            //         suggestions or analyses.
-            void set_queue_limit(unsigned long limit);
-            //! @brief set upper limit for weights
-            void set_weight_limit(Weight limit);
-            //! @brief set search beam
-            void set_beam(Weight beam);
-            //! @brief set time cutoff for correcting
-            void set_time_cutoff(float time_cutoff);
-            //! @brief construct speller from named file containing valid
-            //!        zhfst archive.
-            void read_zhfst(const std::string& filename);
+    //! @brief assign a speller-suggestor circumventing the ZHFST format
+    void inject_speller(Speller* s);
+    //! @brief set upper limit to priority queue when performing
+    //         suggestions or analyses.
+    void set_queue_limit(unsigned long limit);
+    //! @brief set upper limit for weights
+    void set_weight_limit(Weight limit);
+    //! @brief set search beam
+    void set_beam(Weight beam);
+    //! @brief set time cutoff for correcting
+    void set_time_cutoff(float time_cutoff);
+    //! @brief construct speller from named file containing valid
+    //!        zhfst archive.
+    void read_zhfst(const std::string& filename);
 
-            //! @brief  check if the given word is spelled correctly
-            bool spell(const std::string& wordform);
-            //! @brief construct an ordered set of corrections for misspelled
-            //!        word form.
-            CorrectionQueue suggest(const std::string& wordform);
-            //! @brief analyse word form morphologically
-            //! @param wordform   the string to analyse
-            //! @param ask_sugger whether to use the spelling correction model
-            //                    instead of the detection model
-            AnalysisQueue analyse(const std::string& wordform, 
-                                  bool ask_sugger = false);
-            //! @brief construct an ordered set of corrections with analyses
-            AnalysisCorrectionQueue suggest_analyses(const std::string&
-                                                     wordform);
-            //! @brief hyphenate word form
-            HyphenationQueue hyphenate(const std::string& wordform);
+    //! @brief  check if the given word is spelled correctly
+    bool spell(const std::string& wordform);
+    //! @brief construct an ordered set of corrections for misspelled
+    //!        word form.
+    CorrectionQueue suggest(const std::string& wordform);
+    //! @brief analyse word form morphologically
+    //! @param wordform   the string to analyse
+    //! @param ask_sugger whether to use the spelling correction model
+    //                    instead of the detection model
+    AnalysisQueue analyse(const std::string& wordform,
+                          bool ask_sugger=false);
+    //! @brief construct an ordered set of corrections with analyses
+    AnalysisCorrectionQueue suggest_analyses(const std::string&
+                                             wordform);
+    //! @brief hyphenate word form
+    HyphenationQueue hyphenate(const std::string& wordform);
 
-            //! @brief get access to metadata read from XML.
-            const ZHfstOspellerXmlMetadata& get_metadata() const;
-            //! @brief create string representation of the speller for
-            //!        programmer to debug
-            std::string metadata_dump() const;
-        private:
-            //! @brief file or path where the speller came from
-            std::string filename_;
-            //! @brief upper bound for suggestions generated and given
-            unsigned long suggestions_maximum_;
-            //! @brief upper bound for suggestion weight generated and given
-            Weight maximum_weight_;
-            //! @brief upper bound for search beam around best candidate
-            Weight beam_;
-            //! @brief upper bound for search time in seconds
-            float time_cutoff_;
-            //! @brief whether automatons loaded yet can be used to check
-            //!        spelling
-            bool can_spell_;
-            //! @brief whether automatons loaded yet can be used to correct
-            //!        word forms
-            bool can_correct_;
-            //! @brief whether automatons loaded yet can be used to analyse
-            //!        word forms
-            bool can_analyse_;
-            //! @brief whether automatons loaded yet can be used to hyphenate
-            //!        word forms
-            bool can_hyphenate_;
-            //! @brief dictionaries loaded
-            std::map<std::string, Transducer*> acceptors_;
-            //! @brief error models loaded
-            std::map<std::string, Transducer*> errmodels_;
-            //! @brief pointer to current speller
-            Speller* current_speller_;
-            //! @brief pointer to current correction model
-            Speller* current_sugger_;
-            //! @brief pointer to current morphological analyser
-            Speller* current_analyser_;
-            //! @brief pointer to current hyphenator
-            Transducer* current_hyphenator_;
-            //! @brief the metadata of loaded speller
-            ZHfstOspellerXmlMetadata metadata_;
-      };
+    //! @brief get access to metadata read from XML.
+    const ZHfstOspellerXmlMetadata& get_metadata() const;
+    //! @brief create string representation of the speller for
+    //!        programmer to debug
+    std::string metadata_dump() const;
+private:
+    //! @brief file or path where the speller came from
+    std::string filename_;
+    //! @brief upper bound for suggestions generated and given
+    unsigned long suggestions_maximum_;
+    //! @brief upper bound for suggestion weight generated and given
+    Weight maximum_weight_;
+    //! @brief upper bound for search beam around best candidate
+    Weight beam_;
+    //! @brief upper bound for search time in seconds
+    float time_cutoff_;
+    //! @brief whether automatons loaded yet can be used to check
+    //!        spelling
+    bool can_spell_;
+    //! @brief whether automatons loaded yet can be used to correct
+    //!        word forms
+    bool can_correct_;
+    //! @brief whether automatons loaded yet can be used to analyse
+    //!        word forms
+    bool can_analyse_;
+    //! @brief whether automatons loaded yet can be used to hyphenate
+    //!        word forms
+    bool can_hyphenate_;
+    //! @brief dictionaries loaded
+    std::map<std::string, Transducer*> acceptors_;
+    //! @brief error models loaded
+    std::map<std::string, Transducer*> errmodels_;
+    //! @brief pointer to current speller
+    Speller* current_speller_;
+    //! @brief pointer to current correction model
+    Speller* current_sugger_;
+    //! @brief pointer to current morphological analyser
+    Speller* current_analyser_;
+    //! @brief pointer to current hyphenator
+    Transducer* current_hyphenator_;
+    //! @brief the metadata of loaded speller
+    ZHfstOspellerXmlMetadata metadata_;
+};
 
-    //! @brief Top-level exception for zhfst handling.
+//! @brief Top-level exception for zhfst handling.
 
-    //! Contains a human-readable error message that can be displayed to
-    //! end-user as additional info when either solving exception or exiting.
-    class ZHfstException
-      {
-        public:
-            ZHfstException();
-            //! @brief construct error with human readable message.
-            //!
-            //! the message will be displayed when recovering or dying from
-            //! exception
-            explicit ZHfstException(const std::string& message);
-            //!
-            //! format error as user-readable message
-            const char* what();
-        private:
-            std::string what_;
-      };
-
-    //! @brief Generic error in metadata parsing.
-    //
-    //! Gets raised if metadata is erroneous or missing.
-    class ZHfstMetaDataParsingError : public ZHfstException
-    {
-        public:
-            explicit ZHfstMetaDataParsingError(const std::string& message);
-        private:
-            std::string what_;
-    };
-
-    //! @brief Exception for XML parser errors.
-    //
-    //! Gets raised if underlying XML parser finds an error in XML data.
-    //! Errors include non-valid XML, missing or erroneous attributes or
-    //! elements, etc.
-    class ZHfstXmlParsingError : public ZHfstException
-    {
-      public:
-          explicit ZHfstXmlParsingError(const std::string& message);
-      private:
-          std::string what_;
-    };
-
-    //! @brief Generic error while reading zip file.
+//! Contains a human-readable error message that can be displayed to
+//! end-user as additional info when either solving exception or exiting.
+class ZHfstException
+{
+public:
+    ZHfstException();
+    //! @brief construct error with human readable message.
     //!
-    //! Happens when libarchive is unable to proceed reading zip file or
-    //! zip file is missing required files.
-    class ZHfstZipReadingError : public ZHfstException
-    {
-      public:
-          explicit ZHfstZipReadingError(const std::string& message);
-      private:
-          std::string what_;
-    };
+    //! the message will be displayed when recovering or dying from
+    //! exception
+    explicit ZHfstException(const std::string& message);
+    //!
+    //! format error as user-readable message
+    const char* what();
+private:
+    std::string what_;
+};
 
-    //! @brief Error when writing to temporary location.
-    //
-    //! This exception gets thrown, when e.g., zip extraction is unable to
-    //! find or open temporary file for writing.
-    class ZHfstTemporaryWritingError : public ZHfstException
-    {
-      public:
-          explicit ZHfstTemporaryWritingError(const std::string& message);
-      private:
-          std::string what_;
-    };
+//! @brief Generic error in metadata parsing.
+//
+//! Gets raised if metadata is erroneous or missing.
+class ZHfstMetaDataParsingError : public ZHfstException
+{
+public:
+    explicit ZHfstMetaDataParsingError(const std::string& message);
+private:
+    std::string what_;
+};
 
-  } // namespace hfst_ol
+//! @brief Exception for XML parser errors.
+//
+//! Gets raised if underlying XML parser finds an error in XML data.
+//! Errors include non-valid XML, missing or erroneous attributes or
+//! elements, etc.
+class ZHfstXmlParsingError : public ZHfstException
+{
+public:
+    explicit ZHfstXmlParsingError(const std::string& message);
+private:
+    std::string what_;
+};
+
+//! @brief Generic error while reading zip file.
+//!
+//! Happens when libarchive is unable to proceed reading zip file or
+//! zip file is missing required files.
+class ZHfstZipReadingError : public ZHfstException
+{
+public:
+    explicit ZHfstZipReadingError(const std::string& message);
+private:
+    std::string what_;
+};
+
+//! @brief Error when writing to temporary location.
+//
+//! This exception gets thrown, when e.g., zip extraction is unable to
+//! find or open temporary file for writing.
+class ZHfstTemporaryWritingError : public ZHfstException
+{
+public:
+    explicit ZHfstTemporaryWritingError(const std::string& message);
+private:
+    std::string what_;
+};
+
+} // namespace hfst_ol
 
 
 #endif // HFST_OSPELL_OSPELLER_SET_H_

--- a/ZHfstOspellerXmlMetadata.cc
+++ b/ZHfstOspellerXmlMetadata.cc
@@ -39,985 +39,808 @@ using std::map;
 #include "ZHfstOspeller.h"
 #include "ZHfstOspellerXmlMetadata.h"
 
-namespace hfst_ol 
-  {
+namespace hfst_ol
+{
 
 ZHfstOspellerXmlMetadata::ZHfstOspellerXmlMetadata()
-  {
+{
     info_.locale_ = "und";
-  }
+}
 
 static
 bool
 validate_automaton_id(const char* id)
-  {
+{
     const char* p = strchr(id, '.');
-    if (p == NULL)
-      {
+    if (p == NULL) {
         return false;
-      }
+    }
     const char* q = strchr(p + 1, '.');
-    if (q == NULL)
-      {
+    if (q == NULL) {
         return false;
-      }
+    }
     return true;
-  }
+}
 
 static
 char*
 get_automaton_descr_from_id(const char* id)
-  {
+{
     const char* p = strchr(id, '.');
     const char* q = strchr(p + 1, '.');
     return hfst_strndup(p + 1, q - p);
-  }
+}
 
 
 #if HAVE_LIBXML
 void
 ZHfstOspellerXmlMetadata::verify_hfstspeller(xmlpp::Node* rootNode)
-  {
+{
     xmlpp::Element* rootElement = dynamic_cast<xmlpp::Element*>(rootNode);
-    if (NULL == rootElement)
-      {
+    if (NULL == rootElement) {
         throw ZHfstMetaDataParsingError("Root node is not an element");
-      }
+    }
     const Glib::ustring rootName = rootElement->get_name();
-    if (rootName != "hfstspeller")
-      {
+    if (rootName != "hfstspeller") {
         throw ZHfstMetaDataParsingError("could not find <hfstspeller> "
                                         "root from XML file");
-      }
+    }
     // check versions
-    const xmlpp::Attribute* hfstversion = 
+    const xmlpp::Attribute* hfstversion =
         rootElement->get_attribute("hfstversion");
-    if (NULL == hfstversion)
-      {
+    if (NULL == hfstversion) {
         throw ZHfstMetaDataParsingError("No hfstversion attribute in root");
-      }
+    }
     const Glib::ustring hfstversionValue = hfstversion->get_value();
-    if (hfstversionValue != "3")
-      {
+    if (hfstversionValue != "3") {
         throw ZHfstMetaDataParsingError("Unrecognised HFST version...");
-      }
+    }
     const xmlpp::Attribute* dtdversion = rootElement->get_attribute("dtdversion");
-    if (NULL == dtdversion)
-      {
+    if (NULL == dtdversion) {
         throw ZHfstMetaDataParsingError("No dtdversion attribute in root");
-      }
+    }
     const Glib::ustring dtdversionValue = dtdversion->get_value();
-    if (dtdversionValue != "1.0")
-      {
+    if (dtdversionValue != "1.0") {
         throw ZHfstMetaDataParsingError("Unrecognised DTD version...");
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_info(xmlpp::Node* infoNode)
-  {
+{
     xmlpp::Node::NodeList infos = infoNode->get_children();
     for (xmlpp::Node::NodeList::iterator info = infos.begin();
          info != infos.end();
-         ++info)
-      {
+         ++info) {
         const Glib::ustring infoName = (*info)->get_name();
-        if (infoName == "locale")
-          {
+        if (infoName == "locale") {
             parse_locale(*info);
-          }
-        else if (infoName == "title")
-          {
+        } else if (infoName == "title") {
             parse_title(*info);
-          }
-        else if (infoName == "description")
-          {
+        } else if (infoName == "description") {
             parse_description(*info);
-          }
-        else if (infoName == "version")
-          {
+        } else if (infoName == "version") {
             parse_version(*info);
-          }
-        else if (infoName == "date")
-          {
+        } else if (infoName == "date") {
             parse_date(*info);
-          }
-        else if (infoName == "producer")
-          {
+        } else if (infoName == "producer") {
             parse_producer(*info);
-          }
-        else if (infoName == "contact")
-          {
+        } else if (infoName == "contact") {
             parse_contact(*info);
-          }
-        else
-          {
+        } else {
             const xmlpp::TextNode* text = dynamic_cast<xmlpp::TextNode*>(*info);
-            if ((text == NULL) || (!text->is_white_space()))
-              {
+            if ((text == NULL) || (!text->is_white_space())) {
                 fprintf(stderr, "DEBUG: unknown info child %s\n",
                         infoName.c_str());
-              }
-          }
-      } // while info childs
-  }
+            }
+        }
+    } // while info childs
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_locale(xmlpp::Node* localeNode)
-  {
+{
     xmlpp::Element* localeElement = dynamic_cast<xmlpp::Element*>(localeNode);
-    if (NULL == localeElement->get_child_text())
-      {
+    if (NULL == localeElement->get_child_text()) {
         throw ZHfstXmlParsingError("<locale> must be non-empty");
-      }
+    }
     const Glib::ustring localeContent = localeElement->get_child_text()->get_content();
-    if ((info_.locale_ != "und") && (info_.locale_ != localeContent))
-      {
+    if ((info_.locale_ != "und") && (info_.locale_ != localeContent)) {
         // locale in XML mismatches previous definition
         // warnable, but overridden as per spec.
         fprintf(stderr, "Warning: mismatched languages in "
                 "file data (%s) and XML (%s)\n",
                 info_.locale_.c_str(), localeContent.c_str());
-      }
+    }
     info_.locale_ = localeContent;
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_title(xmlpp::Node* titleNode)
-  {
+{
     xmlpp::Element* titleElement = dynamic_cast<xmlpp::Element*>(titleNode);
     const xmlpp::Attribute* lang = titleElement->get_attribute("lang");
-    if (NULL == titleElement->get_child_text())
-      {
+    if (NULL == titleElement->get_child_text()) {
         throw ZHfstXmlParsingError("<title> must be non-empty");
-      }
-    if (lang != NULL)
-      {
+    }
+    if (lang != NULL) {
         info_.title_[lang->get_value()] = titleElement->get_child_text()->get_content();
-      }
-    else
-      {
+    } else {
         info_.title_[info_.locale_] = titleElement->get_child_text()->get_content();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_description(xmlpp::Node* descriptionNode)
-  {
-    xmlpp::Element* descriptionElement = 
+{
+    xmlpp::Element* descriptionElement =
         dynamic_cast<xmlpp::Element*>(descriptionNode);
     const xmlpp::Attribute* lang = descriptionElement->get_attribute("lang");
-    if (NULL == descriptionElement->get_child_text())
-      {
+    if (NULL == descriptionElement->get_child_text()) {
         throw ZHfstXmlParsingError("<description> must be non-empty");
-      }
-    if (lang != NULL)
-      {
+    }
+    if (lang != NULL) {
         info_.description_[lang->get_value()] =
-          descriptionElement->get_child_text()->get_content();
-      }
-    else
-      {
+            descriptionElement->get_child_text()->get_content();
+    } else {
         info_.description_[info_.locale_] =
-          descriptionElement->get_child_text()->get_content();
-      }
-  }
+            descriptionElement->get_child_text()->get_content();
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_version(xmlpp::Node* versionNode)
-  {
+{
     xmlpp::Element* versionElement = dynamic_cast<xmlpp::Element*>(versionNode);
     const xmlpp::Attribute* revision = versionElement->get_attribute("vcsrev");
-    if (revision != NULL)
-      {
+    if (revision != NULL) {
         info_.vcsrev_ = revision->get_value();
-      }
+    }
     info_.version_ = versionElement->get_child_text()->get_content();
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_date(xmlpp::Node* dateNode)
-  {
-    xmlpp::Element* dateElement = 
+{
+    xmlpp::Element* dateElement =
         dynamic_cast<xmlpp::Element*>(dateNode);
     info_.date_ = dateElement->get_child_text()->get_content();
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_producer(xmlpp::Node* producerNode)
-  {
-    xmlpp::Element* producerElement = 
+{
+    xmlpp::Element* producerElement =
         dynamic_cast<xmlpp::Element*>(producerNode);
     info_.producer_ = producerElement->get_child_text()->get_content();
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_contact(xmlpp::Node* contactNode)
-  {
+{
     xmlpp::Element* contactElement = dynamic_cast<xmlpp::Element*>(contactNode);
     const xmlpp::Attribute* email = contactElement->get_attribute("email");
     const xmlpp::Attribute* website = contactElement->get_attribute("website");
-    if (email != NULL)
-      {
+    if (email != NULL) {
         info_.email_ = email->get_value();
-      }
-    if (website != NULL)
-      {
+    }
+    if (website != NULL) {
         info_.website_ = website->get_value();
-      }
-  }
+    }
+}
 
 
 void
 ZHfstOspellerXmlMetadata::parse_acceptor(xmlpp::Node* acceptorNode)
-  {
-    xmlpp::Element* acceptorElement = 
+{
+    xmlpp::Element* acceptorElement =
         dynamic_cast<xmlpp::Element*>(acceptorNode);
     xmlpp::Attribute* xid = acceptorElement->get_attribute("id");
-    if (xid == NULL)
-      {
+    if (xid == NULL) {
         throw ZHfstMetaDataParsingError("id missing in acceptor");
-      }
+    }
     const Glib::ustring xidValue = xid->get_value();
-    if (validate_automaton_id(xidValue.c_str()) == false)
-      {
+    if (validate_automaton_id(xidValue.c_str()) == false) {
         throw ZHfstMetaDataParsingError("Invalid id in acceptor");
-      }
+    }
     char* descr = get_automaton_descr_from_id(xidValue.c_str());
     acceptor_[descr].descr_ = descr;
     acceptor_[descr].id_ = xidValue;
-    const xmlpp::Attribute* trtype = 
+    const xmlpp::Attribute* trtype =
         acceptorElement->get_attribute("transtype");
-    if (trtype != NULL)
-      {
+    if (trtype != NULL) {
         acceptor_[descr].transtype_ = trtype->get_value();
-      }
+    }
     const xmlpp::Attribute* xtype = acceptorElement->get_attribute("type");
-    if (xtype != NULL)
-      {
+    if (xtype != NULL) {
         acceptor_[descr].type_ = xtype->get_value();
-      }
+    }
     xmlpp::Node::NodeList accs = acceptorNode->get_children();
     for (xmlpp::Node::NodeList::iterator acc = accs.begin();
          acc != accs.end();
-         ++acc)
-      {
+         ++acc) {
         const Glib::ustring accName = (*acc)->get_name();
-        if (accName == "title")
-          {
+        if (accName == "title") {
             parse_title(*acc, descr);
-          }
-        else if (accName == "description")
-          {
+        } else if (accName == "description") {
             parse_description(*acc, descr);
-          }
-        else
-          {
+        } else {
             const xmlpp::TextNode* text = dynamic_cast<xmlpp::TextNode*>(*acc);
-            if ((text == NULL) || (!text->is_white_space()))
-              {
+            if ((text == NULL) || (!text->is_white_space())) {
                 fprintf(stderr, "DEBUG: unknown acceptor node %s\n",
                         accName.c_str());
-              }
-          }
-      }
+            }
+        }
+    }
     free(descr);
-  }
+}
 
 void
-ZHfstOspellerXmlMetadata::parse_title(xmlpp::Node* titleNode, 
+ZHfstOspellerXmlMetadata::parse_title(xmlpp::Node* titleNode,
                                       const string& descr)
-  {
+{
     xmlpp::Element* titleElement = dynamic_cast<xmlpp::Element*>(titleNode);
     const xmlpp::Attribute* lang = titleElement->get_attribute("lang");
-    if (lang != NULL)
-      {
+    if (lang != NULL) {
         acceptor_[descr].title_[lang->get_value()] = titleElement->get_child_text()->get_content();
-      }
-    else
-      {
+    } else {
         acceptor_[descr].title_[info_.locale_] = titleElement->get_child_text()->get_content();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_description(xmlpp::Node* descriptionNode,
                                             const string& descr)
-  {
-    xmlpp::Element* descriptionElement = 
+{
+    xmlpp::Element* descriptionElement =
         dynamic_cast<xmlpp::Element*>(descriptionNode);
     const xmlpp::Attribute* lang = descriptionElement->get_attribute("lang");
-    if (lang != NULL)
-      {
+    if (lang != NULL) {
         acceptor_[descr].description_[lang->get_value()] = descriptionElement->get_child_text()->get_content();
-      }
-    else
-      {
+    } else {
         acceptor_[descr].description_[info_.locale_] = descriptionElement->get_child_text()->get_content();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_errmodel(xmlpp::Node* errmodelNode)
-  {
-    xmlpp::Element* errmodelElement = 
+{
+    xmlpp::Element* errmodelElement =
         dynamic_cast<xmlpp::Element*>(errmodelNode);
     xmlpp::Attribute* xid = errmodelElement->get_attribute("id");
-    if (xid == NULL)
-      {
+    if (xid == NULL) {
         throw ZHfstMetaDataParsingError("id missing in errmodel");
-      }
+    }
     const Glib::ustring xidValue = xid->get_value();
-    if (validate_automaton_id(xidValue.c_str()) == false)
-      {
+    if (validate_automaton_id(xidValue.c_str()) == false) {
         throw ZHfstMetaDataParsingError("Invalid id in errmodel");
-      }
+    }
     char* descr = get_automaton_descr_from_id(xidValue.c_str());
     errmodel_.push_back(ZHfstOspellerErrModelMetadata());
     size_t errm_count = errmodel_.size() - 1;
-    if (descr != NULL)
-      {
+    if (descr != NULL) {
         errmodel_[errm_count].descr_ = descr;
-      }
+    }
     free(descr);
     errmodel_[errm_count].id_ = xidValue;
     xmlpp::Node::NodeList errms = errmodelNode->get_children();
     for (xmlpp::Node::NodeList::iterator errm = errms.begin();
-           errm != errms.end();
-           ++errm)
-      {
+         errm != errms.end();
+         ++errm) {
         const Glib::ustring errmName = (*errm)->get_name();
-        if (errmName == "title")
-          {
+        if (errmName == "title") {
             parse_title(*errm, errm_count);
-          }
-        else if (errmName == "description")
-          {
+        } else if (errmName == "description") {
             parse_description(*errm, errm_count);
-          }
-        else if (errmName == "type")
-          {
+        } else if (errmName == "type") {
             parse_type(*errm, errm_count);
-          }
-        else if (errmName == "model")
-          {
+        } else if (errmName == "model") {
             parse_model(*errm, errm_count);
-          }
-        else
-          {
+        } else {
             const xmlpp::TextNode* text = dynamic_cast<xmlpp::TextNode*>(*errm);
-            if ((text == NULL) || (!text->is_white_space()))
-              {
+            if ((text == NULL) || (!text->is_white_space())) {
                 fprintf(stderr, "DEBUG: unknown errmodel node %s\n",
                         errmName.c_str());
-              }
-          }
-      }
-  }
+            }
+        }
+    }
+}
 
 void
-ZHfstOspellerXmlMetadata::parse_title(xmlpp::Node* titleNode, 
+ZHfstOspellerXmlMetadata::parse_title(xmlpp::Node* titleNode,
                                       size_t errm_count)
-  {
+{
     xmlpp::Element* titleElement = dynamic_cast<xmlpp::Element*>(titleNode);
     const xmlpp::Attribute* lang = titleElement->get_attribute("lang");
-    if (lang != NULL)
-      {
+    if (lang != NULL) {
         errmodel_[errm_count].title_[lang->get_value()] = titleElement->get_child_text()->get_content();
-      }
-    else
-      {
+    } else {
         errmodel_[errm_count].title_[info_.locale_] = titleElement->get_child_text()->get_content();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_description(xmlpp::Node* descriptionNode,
                                             size_t errm_count)
-  {
-    xmlpp::Element* descriptionElement = 
+{
+    xmlpp::Element* descriptionElement =
         dynamic_cast<xmlpp::Element*>(descriptionNode);
     const xmlpp::Attribute* lang = descriptionElement->get_attribute("lang");
-    if (lang != NULL)
-      {
+    if (lang != NULL) {
         errmodel_[errm_count].description_[lang->get_value()] = descriptionElement->get_child_text()->get_content();
-      }
-    else
-      {
+    } else {
         errmodel_[errm_count].description_[info_.locale_] = descriptionElement->get_child_text()->get_content();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_type(xmlpp::Node* typeNode, size_t errm_count)
-  {
+{
     xmlpp::Element* typeElement = dynamic_cast<xmlpp::Element*>(typeNode);
     const xmlpp::Attribute* xtype = typeElement->get_attribute("type");
-    if (xtype != NULL)
-      {
+    if (xtype != NULL) {
         errmodel_[errm_count].type_.push_back(xtype->get_value());
 
-      }
-    else
-      {
+    } else {
         throw ZHfstMetaDataParsingError("No type in type");
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_model(xmlpp::Node* modelNode, size_t errm_count)
-  {
+{
     xmlpp::Element* modelElement = dynamic_cast<xmlpp::Element*>(modelNode);
     errmodel_[errm_count].model_.push_back(modelElement->get_child_text()->get_content());
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_xml(const xmlpp::Document* doc)
-  {
-    if (NULL == doc)
-      {
+{
+    if (NULL == doc) {
         throw ZHfstMetaDataParsingError("Cannot parse XML data");
-      }
+    }
     xmlpp::Node* rootNode = doc->get_root_node();
     // check validity
-    if (NULL == rootNode)
-      {
+    if (NULL == rootNode) {
         throw ZHfstMetaDataParsingError("No root node in index XML");
-      }
+    }
     verify_hfstspeller(rootNode);
-    // parse 
+    // parse
     xmlpp::Node::NodeList nodes = rootNode->get_children();
     for (xmlpp::Node::NodeList::iterator node = nodes.begin();
          node != nodes.end();
-         ++node)
-      {
+         ++node) {
         const Glib::ustring nodename = (*node)->get_name();
-        if (nodename == "info")
-          {
+        if (nodename == "info") {
             parse_info(*node);
-          } // if info node
-        else if (nodename == "acceptor")
-          {
+        } // if info node
+        else if (nodename == "acceptor") {
             parse_acceptor(*node);
-          } // acceptor node
-        else if (nodename == "errmodel")
-          {
+        } // acceptor node
+        else if (nodename == "errmodel") {
             parse_errmodel(*node);
-          } // errmodel node
-        else
-          {
+        } // errmodel node
+        else {
             const xmlpp::TextNode* text = dynamic_cast<xmlpp::TextNode*>(*node);
-            if ((text == NULL) || (!text->is_white_space()))
-              {
+            if ((text == NULL) || (!text->is_white_space())) {
                 fprintf(stderr, "DEBUG: unknown root child %s\n",
                         nodename.c_str());
-              }
-          } // unknown root child node
-      }
-  }
+            }
+        } // unknown root child node
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::read_xml(const char* xml_data, size_t xml_len)
-  {
+{
     xmlpp::DomParser parser;
     parser.set_substitute_entities();
     parser.parse_memory_raw(reinterpret_cast<const unsigned char*>(xml_data),
                             xml_len);
     this->parse_xml(parser.get_document());
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::read_xml(const string& filename)
-  {
+{
     xmlpp::DomParser parser;
     parser.set_substitute_entities();
     parser.parse_file(filename);
     this->parse_xml(parser.get_document());
-  }
+}
 #elif HAVE_TINYXML2
 
 void
 ZHfstOspellerXmlMetadata::parse_xml(const tinyxml2::XMLDocument& doc)
-  {
+{
     const tinyxml2::XMLElement* rootNode = doc.RootElement();
-    if (NULL == rootNode)
-      {
+    if (NULL == rootNode) {
         throw ZHfstMetaDataParsingError("No root node in index XML");
-      }
+    }
     // check validity
-    if (strcmp(rootNode->Name(), "hfstspeller") != 0)
-      {
+    if (strcmp(rootNode->Name(), "hfstspeller") != 0) {
         throw ZHfstMetaDataParsingError("could not find <hfstspeller> "
                                         "root from XML file");
-      }
+    }
     verify_hfstspeller(*rootNode);
     // parse
     const tinyxml2::XMLElement* child = rootNode->FirstChildElement();
-    while (child != NULL)
-      {
-        if (strcmp(child->Name(), "info") == 0)
-          {
+    while (child != NULL) {
+        if (strcmp(child->Name(), "info") == 0) {
             parse_info(*child);
-          }
-        else if (strcmp(child->Name(), "acceptor") == 0)
-          {
+        } else if (strcmp(child->Name(), "acceptor") == 0) {
             parse_acceptor(*child);
-          }
-        else if (strcmp(child->Name(), "errmodel") == 0)
-          {
+        } else if (strcmp(child->Name(), "errmodel") == 0) {
             parse_errmodel(*child);
-          }
-        else
-          {
+        } else {
             fprintf(stderr, "DEBUG: Unknown root child %s\n",
                     child->Name());
-          }
+        }
         child = child->NextSiblingElement();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::verify_hfstspeller(const tinyxml2::XMLElement& hfstspellerNode)
-  {
-    if (!hfstspellerNode.Attribute("hfstversion"))
-      {
+{
+    if (!hfstspellerNode.Attribute("hfstversion")) {
         throw ZHfstMetaDataParsingError("No hfstversion attribute in root");
-      }
-    if (!hfstspellerNode.Attribute("hfstversion", "3"))
-      {
+    }
+    if (!hfstspellerNode.Attribute("hfstversion", "3")) {
         throw ZHfstMetaDataParsingError("Unrecognised HFST version...");
-      }
-    if (!hfstspellerNode.Attribute("dtdversion"))
-      {
+    }
+    if (!hfstspellerNode.Attribute("dtdversion")) {
         throw ZHfstMetaDataParsingError("No dtdversion attribute in root");
-      }
-    if (!hfstspellerNode.Attribute("dtdversion", "1.0"))
-      {
+    }
+    if (!hfstspellerNode.Attribute("dtdversion", "1.0")) {
         throw ZHfstMetaDataParsingError("Unrecognised DTD version...");
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_info(const tinyxml2::XMLElement& infoNode)
-  {
+{
     const tinyxml2::XMLElement* info = infoNode.FirstChildElement();
-    while (info != NULL)
-      {
-        if (strcmp(info->Name(), "locale") == 0)
-          {
+    while (info != NULL) {
+        if (strcmp(info->Name(), "locale") == 0) {
             parse_locale(*info);
-          }
-        else if (strcmp(info->Name(), "title") == 0)
-          {
+        } else if (strcmp(info->Name(), "title") == 0) {
             parse_title(*info);
-          }
-        else if (strcmp(info->Name(), "description") == 0)
-          {
+        } else if (strcmp(info->Name(), "description") == 0) {
             parse_description(*info);
-          }
-        else if (strcmp(info->Name(), "version") == 0)
-          {
+        } else if (strcmp(info->Name(), "version") == 0) {
             parse_version(*info);
-          }
-        else if (strcmp(info->Name(), "date") == 0)
-          {
+        } else if (strcmp(info->Name(), "date") == 0) {
             parse_date(*info);
-          }
-        else if (strcmp(info->Name(), "producer") == 0)
-          {
+        } else if (strcmp(info->Name(), "producer") == 0) {
             parse_producer(*info);
-          }
-        else if (strcmp(info->Name(), "contact") == 0)
-          {
+        } else if (strcmp(info->Name(), "contact") == 0) {
             parse_contact(*info);
-          }
-        else
-          {
+        } else {
             fprintf(stderr, "DEBUG: unknown info child %s\n",
                     info->Name());
-          }
+        }
         info = info->NextSiblingElement();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_locale(const tinyxml2::XMLElement& localeNode)
-  {
+{
     const char* localeContent = localeNode.GetText();
-    if (NULL == localeNode.GetText())
-      {
+    if (NULL == localeNode.GetText()) {
         throw ZHfstXmlParsingError("<locale> must be non-empty");
-      }
-    if ((info_.locale_ != "und") && (info_.locale_ != localeContent))
-      {
+    }
+    if ((info_.locale_ != "und") && (info_.locale_ != localeContent)) {
         // locale in XML mismatches previous definition
         // warnable, but overridden as per spec.
         fprintf(stderr, "Warning: mismatched languages in "
                 "file data (%s) and XML (%s)\n",
                 info_.locale_.c_str(), localeContent);
-      }
+    }
     info_.locale_ = localeContent;
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_title(const tinyxml2::XMLElement& titleNode)
-  {
-    if (NULL == titleNode.GetText())
-      {
+{
+    if (NULL == titleNode.GetText()) {
         throw ZHfstXmlParsingError("<title> must be non-empty");
-      }
-    if (titleNode.Attribute("lang"))
-      {
+    }
+    if (titleNode.Attribute("lang")) {
         info_.title_[titleNode.Attribute("lang")] = titleNode.GetText();
-      }
-    else
-      {
+    } else {
         info_.title_[info_.locale_] = titleNode.GetText();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_description(const tinyxml2::XMLElement& descriptionNode)
-  {
-    if (NULL == descriptionNode.GetText())
-      {
+{
+    if (NULL == descriptionNode.GetText()) {
         throw ZHfstXmlParsingError("<description> must be non-empty");
-      }
-    if (descriptionNode.Attribute("lang"))
-      {
+    }
+    if (descriptionNode.Attribute("lang")) {
         info_.description_[descriptionNode.Attribute("lang")] =
-          descriptionNode.GetText();
-      }
-    else
-      {
+            descriptionNode.GetText();
+    } else {
         info_.description_[info_.locale_] = descriptionNode.GetText();
-      }
-    
-  }
+    }
+
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_version(const tinyxml2::XMLElement& versionNode)
-  {
-    if (versionNode.Attribute("vcsrev"))
-      {
+{
+    if (versionNode.Attribute("vcsrev")) {
         info_.vcsrev_ = versionNode.Attribute("vcsrev");
-      }
+    }
     info_.version_ = versionNode.GetText();
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_date(const tinyxml2::XMLElement& dateNode)
-  {
+{
     info_.date_ = dateNode.GetText();
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_producer(const tinyxml2::XMLElement& producerNode)
-  {
+{
     info_.producer_ = producerNode.GetText();
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_contact(const tinyxml2::XMLElement& contactNode)
-  {
-    if (contactNode.Attribute("email"))
-      {
+{
+    if (contactNode.Attribute("email")) {
         info_.email_ = contactNode.Attribute("email");
-      }
-    if (contactNode.Attribute("website"))
-      {
+    }
+    if (contactNode.Attribute("website")) {
         info_.website_ = contactNode.Attribute("website");
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_acceptor(const tinyxml2::XMLElement& acceptorNode)
-  {
+{
     const char* xid = acceptorNode.Attribute("id");
-    if (xid == NULL)
-      {
+    if (xid == NULL) {
         throw ZHfstMetaDataParsingError("id missing in acceptor");
-      }
-    if (validate_automaton_id(xid) == false)
-      {
+    }
+    if (validate_automaton_id(xid) == false) {
         throw ZHfstMetaDataParsingError("Invalid id in accpetor");
-      }
+    }
     char* descr = get_automaton_descr_from_id(xid);
     acceptor_[descr].descr_ = descr;
     acceptor_[descr].id_ = xid;
-    if (acceptorNode.Attribute("trtype"))
-      {
+    if (acceptorNode.Attribute("trtype")) {
         acceptor_[descr].transtype_ = acceptorNode.Attribute("trtype");
-      }
-    if (acceptorNode.Attribute("type"))
-      {
+    }
+    if (acceptorNode.Attribute("type")) {
         acceptor_[descr].type_ = acceptorNode.Attribute("type");
-      }
+    }
     const tinyxml2::XMLElement* acc = acceptorNode.FirstChildElement();
-    while (acc != NULL)
-      {
-        if (strcmp(acc->Name(), "title") == 0)
-          {
+    while (acc != NULL) {
+        if (strcmp(acc->Name(), "title") == 0) {
             parse_title(*acc, descr);
-          }
-        else if (strcmp(acc->Name(), "description") == 0)
-          {
+        } else if (strcmp(acc->Name(), "description") == 0) {
             parse_description(*acc, descr);
-          }
-        else
-          {
+        } else {
             fprintf(stderr, "DEBUG: unknown acceptor child %s\n",
                     acc->Name());
-          }
+        }
         acc = acc->NextSiblingElement();
-      }
+    }
     free(descr);
-  }
-                 
+}
+
 void
 ZHfstOspellerXmlMetadata::parse_title(const tinyxml2::XMLElement& titleNode,
                                       const std::string& accName)
-  {
-    if (titleNode.Attribute("lang"))
-      {
+{
+    if (titleNode.Attribute("lang")) {
         acceptor_[accName].title_[titleNode.Attribute("lang")] =
-          titleNode.GetText();
-      }
-    else
-      {
-        acceptor_[accName].title_[info_.locale_] = 
-          titleNode.GetText();
-      }
-  }
-        
+            titleNode.GetText();
+    } else {
+        acceptor_[accName].title_[info_.locale_] =
+            titleNode.GetText();
+    }
+}
+
 
 void
 ZHfstOspellerXmlMetadata::parse_description(const tinyxml2::XMLElement& descriptionNode,
-                       const std::string& accName)
-  {
-    if (descriptionNode.Attribute("lang"))
-      {
+                                            const std::string& accName)
+{
+    if (descriptionNode.Attribute("lang")) {
         acceptor_[accName].description_[descriptionNode.Attribute("lang")] =
-          descriptionNode.GetText();
-      }
-    else
-      {
-        acceptor_[accName].description_[info_.locale_] = 
-          descriptionNode.GetText();
-      }
-  }
+            descriptionNode.GetText();
+    } else {
+        acceptor_[accName].description_[info_.locale_] =
+            descriptionNode.GetText();
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_errmodel(const tinyxml2::XMLElement& errmodelNode)
-  {
+{
     const char* xid = errmodelNode.Attribute("id");
-    if (xid == NULL)
-      {
+    if (xid == NULL) {
         throw ZHfstMetaDataParsingError("id missing in errmodel");
-      }
-    if (validate_automaton_id(xid) == false)
-      {
+    }
+    if (validate_automaton_id(xid) == false) {
         throw ZHfstMetaDataParsingError("Invalid id in errmodel");
-      }
+    }
     char* descr = get_automaton_descr_from_id(xid);
     errmodel_.push_back(ZHfstOspellerErrModelMetadata());
     size_t errm_count = errmodel_.size() - 1;
-    if (descr != NULL)
-      {
+    if (descr != NULL) {
         errmodel_[errm_count].descr_ = descr;
-      }
+    }
     free(descr);
     errmodel_[errm_count].id_ = xid;
     const tinyxml2::XMLElement* errm = errmodelNode.FirstChildElement();
-    while (errm != NULL)
-      {
-        if (strcmp(errm->Name(), "title") == 0)
-          {
+    while (errm != NULL) {
+        if (strcmp(errm->Name(), "title") == 0) {
             parse_title(*errm, errm_count);
-          }
-        else if (strcmp(errm->Name(), "description") == 0)
-          {
+        } else if (strcmp(errm->Name(), "description") == 0) {
             parse_description(*errm, errm_count);
-          }
-        else if (strcmp(errm->Name(), "type") == 0)
-          {
+        } else if (strcmp(errm->Name(), "type") == 0) {
             parse_type(*errm, errm_count);
-          }
-        else if (strcmp(errm->Name(), "model") == 0)
-          {
+        } else if (strcmp(errm->Name(), "model") == 0) {
             parse_model(*errm, errm_count);
-          }
-        else
-          {
+        } else {
             fprintf(stderr, "DEBUG: unknown errmodel child %s\n",
                     errm->Name());
-          }
+        }
         errm = errm->NextSiblingElement();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_title(const tinyxml2::XMLElement& titleNode, size_t errm_count)
-  {
-    if (titleNode.Attribute("lang"))
-      {
+{
+    if (titleNode.Attribute("lang")) {
         errmodel_[errm_count].title_[titleNode.Attribute("lang")] =
-          titleNode.GetText();
-      }
-    else
-      {
+            titleNode.GetText();
+    } else {
         errmodel_[errm_count].title_[info_.locale_] = titleNode.GetText();
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_description(const tinyxml2::XMLElement& descriptionNode, size_t errm_count)
-  {
-    if (descriptionNode.Attribute("lang"))
-      {
+{
+    if (descriptionNode.Attribute("lang")) {
         errmodel_[errm_count].description_[descriptionNode.Attribute("lang")] =
-          descriptionNode.GetText();
-      }
-    else
-      {
-        errmodel_[errm_count].description_[info_.locale_] = 
-          descriptionNode.GetText();
-      }
-  }
+            descriptionNode.GetText();
+    } else {
+        errmodel_[errm_count].description_[info_.locale_] =
+            descriptionNode.GetText();
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_type(const tinyxml2::XMLElement& typeNode, size_t errm_count)
-  {
-    if (typeNode.Attribute("type"))
-      {
+{
+    if (typeNode.Attribute("type")) {
         errmodel_[errm_count].type_.push_back(typeNode.Attribute("type"));
-      }
-    else
-      {
+    } else {
         throw ZHfstMetaDataParsingError("No type in type");
-      }
-  }
+    }
+}
 
 void
 ZHfstOspellerXmlMetadata::parse_model(const tinyxml2::XMLElement& modelNode, size_t errm_count)
-  {
+{
     errmodel_[errm_count].model_.push_back(modelNode.GetText());
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::read_xml(const char* xml_data, size_t xml_len)
-  {
+{
     tinyxml2::XMLDocument doc;
-    if (doc.Parse(xml_data, xml_len) != tinyxml2::XML_NO_ERROR)
-      {
+    if (doc.Parse(xml_data, xml_len) != tinyxml2::XML_NO_ERROR) {
         throw ZHfstMetaDataParsingError("Reading XML from memory");
-      }
+    }
     this->parse_xml(doc);
-  }
+}
 
 void
 ZHfstOspellerXmlMetadata::read_xml(const string& filename)
-  {
+{
     tinyxml2::XMLDocument doc;
-    if (doc.LoadFile(filename.c_str()) != tinyxml2::XML_NO_ERROR)
-      {
+    if (doc.LoadFile(filename.c_str()) != tinyxml2::XML_NO_ERROR) {
         throw ZHfstMetaDataParsingError("Reading XML from file");
-      }
+    }
     this->parse_xml(doc);
-  }
+}
 #else
 #error configure found no usable XML library
 void
-    ZHfstOspellerXmlMetadata::read_xml(const char*, size_t)
-      {}
+ZHfstOspellerXmlMetadata::read_xml(const char*, size_t)
+{
+}
 void
-    ZHfstOspellerXmlMetadata::read_xml(const std::string&)
-      {}
+ZHfstOspellerXmlMetadata::read_xml(const std::string&)
+{
+}
 #endif // HAVE_LIBXML
 
 
 string
 ZHfstOspellerXmlMetadata::debug_dump() const
-  {
+{
     string retval = "locale: " + info_.locale_ + "\n"
-        "version: " + info_.version_ + " [vcsrev: " + info_.vcsrev_ + "]\n"
-        "date: " + info_.date_ + "\n"
-        "producer: " + info_.producer_ + "[email: <" + info_.email_ + ">, "
-        "website: <" + info_.website_ + ">]\n";
-    for (map<string,string>::const_iterator title = info_.title_.begin();
+                    "version: " + info_.version_ + " [vcsrev: " + info_.vcsrev_ + "]\n"
+                    "date: " + info_.date_ + "\n"
+                    "producer: " + info_.producer_ + "[email: <" + info_.email_ + ">, "
+                    "website: <" + info_.website_ + ">]\n";
+    for (map<string, string>::const_iterator title = info_.title_.begin();
          title != info_.title_.end();
-         ++title)
-      {
+         ++title) {
         retval.append("title [" + title->first + "]: " + title->second + "\n");
-      }
-    for (map<string,string>::const_iterator description = info_.description_.begin();
+    }
+    for (map<string, string>::const_iterator description = info_.description_.begin();
          description != info_.description_.end();
-         ++description)
-      {
+         ++description) {
         retval.append("description [" + description->first + "]: " +
-            description->second + "\n");
-      }
-    for (map<string,ZHfstOspellerAcceptorMetadata>::const_iterator acc = acceptor_.begin();
+                      description->second + "\n");
+    }
+    for (map<string, ZHfstOspellerAcceptorMetadata>::const_iterator acc = acceptor_.begin();
          acc != acceptor_.end();
-         ++acc)
-      {
+         ++acc) {
         retval.append("acceptor[" + acc->second.descr_ + "] [id: " + acc->second.id_ +
                       ", type: " + acc->second.type_ + "trtype: " + acc->second.transtype_ +
                       "]\n");
 
         for (LanguageVersions::const_iterator title = acc->second.title_.begin();
              title != acc->second.title_.end();
-             ++title)
-          {
+             ++title) {
             retval.append("title [" + title->first + "]: " + title->second +
                           "\n");
-          }
+        }
         for (LanguageVersions::const_iterator description = acc->second.description_.begin();
              description != acc->second.description_.end();
-             ++description)
-          {
+             ++description) {
             retval.append("description[" + description->first + "]: "
                           + description->second + "\n");
-          }
-      }
+        }
+    }
     for (std::vector<ZHfstOspellerErrModelMetadata>::const_iterator errm = errmodel_.begin();
          errm != errmodel_.end();
-         ++errm)
-      {
+         ++errm) {
         retval.append("errmodel[" + errm->descr_ + "] [id: " + errm->id_ +
                       "]\n");
 
         for (LanguageVersions::const_iterator title = errm->title_.begin();
              title != errm->title_.end();
-             ++title)
-          {
+             ++title) {
             retval.append("title [" + title->first + "]: " + title->second +
                           "\n");
-          }
+        }
         for (LanguageVersions::const_iterator description = errm->description_.begin();
              description != errm->description_.end();
-             ++description)
-          {
+             ++description) {
             retval.append("description[" + description->first + "]: "
                           + description->second + "\n");
-          }
+        }
         for (std::vector<string>::const_iterator type = errm->type_.begin();
              type != errm->type_.end();
-             ++type)
-          {
+             ++type) {
             retval.append("type: " + *type + "\n");
-          }
+        }
         for (std::vector<string>::const_iterator model = errm->model_.begin();
              model != errm->model_.end();
-             ++model)
-          {
+             ++model) {
             retval.append("model: " + *model + "\n");
-          }
-      }
-    
-    return retval;
-  }
+        }
+    }
 
-  } // namespace hfst_ol
+    return retval;
+}
+
+} // namespace hfst_ol
 
 

--- a/ZHfstOspellerXmlMetadata.h
+++ b/ZHfstOspellerXmlMetadata.h
@@ -33,137 +33,137 @@ using std::map;
 #include "ospell.h"
 #include "hfst-ol.h"
 
-namespace hfst_ol 
-  {
-    //! @brief data type for associating set of translations to languages.
-    typedef std::map<std::string,std::string> LanguageVersions;
+namespace hfst_ol
+{
+//! @brief data type for associating set of translations to languages.
+typedef std::map<std::string, std::string> LanguageVersions;
 
 
-    //! @brief ZHfstOspellerInfo represents one info block of an zhfst file.
-    //! @see https://victorio.uit.no/langtech/trunk/plan/proof/doc/lexfile-spec.xml
-    struct ZHfstOspellerInfoMetadata
-      {
-        //! @brief active locale of speller in BCP format
-        std::string locale_;
-        //! @brief transalation of titles to all languages
-        LanguageVersions title_;
-        //! @brief translation of descriptions to all languages
-        LanguageVersions description_;
-        //! @brief version defintition as free form string
-        std::string version_;
-        //! @brief vcs revision as string
-        std::string vcsrev_;
-        //! @brief date for age of speller as string
-        std::string date_;
-        //! @brief producer of the speller
-        std::string producer_;
-        //! @brief email address of the speller
-        std::string email_;
-        //! @brief web address of the speller
-        std::string website_;
-      };
-    //! @brief Represents one acceptor block in XML metadata
-    struct ZHfstOspellerAcceptorMetadata
-      {
-        //! @brief unique id of acceptor
-        std::string id_;
-        //! @brief descr part of acceptor
-        std::string descr_;
-        //! @brief type of dictionary
-        std::string type_;
-        //! @brief type of transducer
-        std::string transtype_;
-        //! @brief titles of dictionary in languages
-        LanguageVersions title_;
-        //! @brief descriptions of dictionary in languages
-        LanguageVersions description_;
-      };
-    //! @brief Represents one errmodel block in XML metadata
-    struct ZHfstOspellerErrModelMetadata
-      {
-        //! @brief id of each error model in set
-        std::string id_;
-        //! @brief descr part of each id
-        std::string descr_;
-        //! @brief title of error models in languages
-        LanguageVersions title_;
-        //! @brief description of error models in languages
-        LanguageVersions description_;
-        //! @brief types of error models
-        std::vector<std::string> type_; 
-        //! @brief models
-        std::vector<std::string> model_;
-      };
-    //! @brief holds one index.xml metadata for whole ospeller
-    class ZHfstOspellerXmlMetadata
-      {
-        public:
-        //! @brief construct metadata for undefined language and other default
-        //!        values
-        ZHfstOspellerXmlMetadata();
-        //! @brief read metadata from XML file by @a filename.
-        void read_xml(const std::string& filename);
-        //! @brief read XML from in memory @a data pointer with given @a length
-        //!
-        //! Depending on the XML library compiled in, the data length may
-        //! be omitted and the buffer may be overflown.
-        void read_xml(const char* data, size_t data_length);
-        //! @brief create a programmer readable dump of XML metadata.
-        //!
-        //! shows linear serialisation of all header data in random order.
-        std::string debug_dump() const;
+//! @brief ZHfstOspellerInfo represents one info block of an zhfst file.
+//! @see https://victorio.uit.no/langtech/trunk/plan/proof/doc/lexfile-spec.xml
+struct ZHfstOspellerInfoMetadata
+{
+    //! @brief active locale of speller in BCP format
+    std::string locale_;
+    //! @brief transalation of titles to all languages
+    LanguageVersions title_;
+    //! @brief translation of descriptions to all languages
+    LanguageVersions description_;
+    //! @brief version defintition as free form string
+    std::string version_;
+    //! @brief vcs revision as string
+    std::string vcsrev_;
+    //! @brief date for age of speller as string
+    std::string date_;
+    //! @brief producer of the speller
+    std::string producer_;
+    //! @brief email address of the speller
+    std::string email_;
+    //! @brief web address of the speller
+    std::string website_;
+};
+//! @brief Represents one acceptor block in XML metadata
+struct ZHfstOspellerAcceptorMetadata
+{
+    //! @brief unique id of acceptor
+    std::string id_;
+    //! @brief descr part of acceptor
+    std::string descr_;
+    //! @brief type of dictionary
+    std::string type_;
+    //! @brief type of transducer
+    std::string transtype_;
+    //! @brief titles of dictionary in languages
+    LanguageVersions title_;
+    //! @brief descriptions of dictionary in languages
+    LanguageVersions description_;
+};
+//! @brief Represents one errmodel block in XML metadata
+struct ZHfstOspellerErrModelMetadata
+{
+    //! @brief id of each error model in set
+    std::string id_;
+    //! @brief descr part of each id
+    std::string descr_;
+    //! @brief title of error models in languages
+    LanguageVersions title_;
+    //! @brief description of error models in languages
+    LanguageVersions description_;
+    //! @brief types of error models
+    std::vector<std::string> type_;
+    //! @brief models
+    std::vector<std::string> model_;
+};
+//! @brief holds one index.xml metadata for whole ospeller
+class ZHfstOspellerXmlMetadata
+{
+public:
+    //! @brief construct metadata for undefined language and other default
+    //!        values
+    ZHfstOspellerXmlMetadata();
+    //! @brief read metadata from XML file by @a filename.
+    void read_xml(const std::string& filename);
+    //! @brief read XML from in memory @a data pointer with given @a length
+    //!
+    //! Depending on the XML library compiled in, the data length may
+    //! be omitted and the buffer may be overflown.
+    void read_xml(const char* data, size_t data_length);
+    //! @brief create a programmer readable dump of XML metadata.
+    //!
+    //! shows linear serialisation of all header data in random order.
+    std::string debug_dump() const;
 
-        public:
-        ZHfstOspellerInfoMetadata info_; //!< The info node data
-        //! @brief data for acceptor nodes
-        std::map<std::string,ZHfstOspellerAcceptorMetadata> acceptor_; 
-        //! @brief data for errmodel nodes
-        std::vector<ZHfstOspellerErrModelMetadata> errmodel_;
+public:
+    ZHfstOspellerInfoMetadata info_; //!< The info node data
+    //! @brief data for acceptor nodes
+    std::map<std::string, ZHfstOspellerAcceptorMetadata> acceptor_;
+    //! @brief data for errmodel nodes
+    std::vector<ZHfstOspellerErrModelMetadata> errmodel_;
 #if HAVE_LIBXML
-        private:
-        void parse_xml(const xmlpp::Document* doc);
-        void verify_hfstspeller(xmlpp::Node* hfstspellerNode);
-        void parse_info(xmlpp::Node* infoNode);
-        void parse_locale(xmlpp::Node* localeNode);
-        void parse_title(xmlpp::Node* titleNode);
-        void parse_description(xmlpp::Node* descriptionNode);
-        void parse_version(xmlpp::Node* versionNode);
-        void parse_date(xmlpp::Node* dateNode);
-        void parse_producer(xmlpp::Node* producerNode);
-        void parse_contact(xmlpp::Node* contactNode);
-        void parse_acceptor(xmlpp::Node* acceptorNode);
-        void parse_title(xmlpp::Node* titleNode, const std::string& accName);
-        void parse_description(xmlpp::Node* descriptionNode,
-                               const std::string& accName);
-        void parse_errmodel(xmlpp::Node* errmodelNode);
-        void parse_title(xmlpp::Node* titleNode, size_t errm_count);
-        void parse_description(xmlpp::Node* descriptionNode, size_t errm_count);
-        void parse_type(xmlpp::Node* typeNode, size_t errm_count);
-        void parse_model(xmlpp::Node* modelNode, size_t errm_count);
+private:
+    void parse_xml(const xmlpp::Document* doc);
+    void verify_hfstspeller(xmlpp::Node* hfstspellerNode);
+    void parse_info(xmlpp::Node* infoNode);
+    void parse_locale(xmlpp::Node* localeNode);
+    void parse_title(xmlpp::Node* titleNode);
+    void parse_description(xmlpp::Node* descriptionNode);
+    void parse_version(xmlpp::Node* versionNode);
+    void parse_date(xmlpp::Node* dateNode);
+    void parse_producer(xmlpp::Node* producerNode);
+    void parse_contact(xmlpp::Node* contactNode);
+    void parse_acceptor(xmlpp::Node* acceptorNode);
+    void parse_title(xmlpp::Node* titleNode, const std::string& accName);
+    void parse_description(xmlpp::Node* descriptionNode,
+                           const std::string& accName);
+    void parse_errmodel(xmlpp::Node* errmodelNode);
+    void parse_title(xmlpp::Node* titleNode, size_t errm_count);
+    void parse_description(xmlpp::Node* descriptionNode, size_t errm_count);
+    void parse_type(xmlpp::Node* typeNode, size_t errm_count);
+    void parse_model(xmlpp::Node* modelNode, size_t errm_count);
 #elif HAVE_TINYXML2
-        private:
-        void parse_xml(const tinyxml2::XMLDocument& doc);
-        void verify_hfstspeller(const tinyxml2::XMLElement& hfstspellerNode);
-        void parse_info(const tinyxml2::XMLElement& infoNode);
-        void parse_locale(const tinyxml2::XMLElement& localeNode);
-        void parse_title(const tinyxml2::XMLElement& titleNode);
-        void parse_description(const tinyxml2::XMLElement& descriptionNode);
-        void parse_version(const tinyxml2::XMLElement& versionNode);
-        void parse_date(const tinyxml2::XMLElement& dateNode);
-        void parse_producer(const tinyxml2::XMLElement& producerNode);
-        void parse_contact(const tinyxml2::XMLElement& contactNode);
-        void parse_acceptor(const tinyxml2::XMLElement& acceptorNode);
-        void parse_title(const tinyxml2::XMLElement& titleNode, const std::string& accName);
-        void parse_description(const tinyxml2::XMLElement& descriptionNode,
-                               const std::string& accName);
-        void parse_errmodel(const tinyxml2::XMLElement& errmodelNode);
-        void parse_title(const tinyxml2::XMLElement& titleNode, size_t errm_count);
-        void parse_description(const tinyxml2::XMLElement& descriptionNode, size_t errm_count);
-        void parse_type(const tinyxml2::XMLElement& typeNode, size_t errm_count);
-        void parse_model(const tinyxml2::XMLElement& modelNode, size_t errm_count);
+private:
+    void parse_xml(const tinyxml2::XMLDocument& doc);
+    void verify_hfstspeller(const tinyxml2::XMLElement& hfstspellerNode);
+    void parse_info(const tinyxml2::XMLElement& infoNode);
+    void parse_locale(const tinyxml2::XMLElement& localeNode);
+    void parse_title(const tinyxml2::XMLElement& titleNode);
+    void parse_description(const tinyxml2::XMLElement& descriptionNode);
+    void parse_version(const tinyxml2::XMLElement& versionNode);
+    void parse_date(const tinyxml2::XMLElement& dateNode);
+    void parse_producer(const tinyxml2::XMLElement& producerNode);
+    void parse_contact(const tinyxml2::XMLElement& contactNode);
+    void parse_acceptor(const tinyxml2::XMLElement& acceptorNode);
+    void parse_title(const tinyxml2::XMLElement& titleNode, const std::string& accName);
+    void parse_description(const tinyxml2::XMLElement& descriptionNode,
+                           const std::string& accName);
+    void parse_errmodel(const tinyxml2::XMLElement& errmodelNode);
+    void parse_title(const tinyxml2::XMLElement& titleNode, size_t errm_count);
+    void parse_description(const tinyxml2::XMLElement& descriptionNode, size_t errm_count);
+    void parse_type(const tinyxml2::XMLElement& typeNode, size_t errm_count);
+    void parse_model(const tinyxml2::XMLElement& modelNode, size_t errm_count);
 
-#endif
-      };
+#endif // if HAVE_LIBXML
+};
 }
 
 #endif // inclusion GUARD

--- a/hfst-ol.cc
+++ b/hfst-ol.cc
@@ -25,7 +25,7 @@ inline T hfst_deref(T* ptr)
     return dest;
 }
 
-void skip_c_string(char ** raw)
+void skip_c_string(char** raw)
 {
     while (**raw != 0) {
         ++(*raw);
@@ -37,17 +37,14 @@ void
 TransducerHeader::read_property(bool& property, FILE* f)
 {
     unsigned int prop;
-    if (fread(&prop,sizeof(unsigned int),1,f) != 1) {
+    if (fread(&prop, sizeof(unsigned int), 1, f) != 1) {
         HFST_THROW_MESSAGE(HeaderParsingException,
                            "Header ended unexpectedly\n");
     }
-    if (prop == 0)
-    {
+    if (prop == 0) {
         property = false;
         return;
-    }
-    else
-    {
+    } else {
         property = true;
         return;
     }
@@ -56,34 +53,29 @@ TransducerHeader::read_property(bool& property, FILE* f)
 void
 TransducerHeader::read_property(bool& property, char** raw)
 {
-    unsigned int prop = *((unsigned int *) *raw);
+    unsigned int prop = *((unsigned int*) *raw);
     (*raw) += sizeof(unsigned int);
-    if (prop == 0)
-    {
+    if (prop == 0) {
         property = false;
         return;
-    }
-    else
-    {
+    } else {
         property = true;
         return;
     }
 }
 
-void TransducerHeader::skip_hfst3_header(FILE * f)
+void TransducerHeader::skip_hfst3_header(FILE* f)
 {
     const char* header1 = "HFST";
     unsigned int header_loc = 0; // how much of the header has been found
     int c;
-    for(header_loc = 0; header_loc < strlen(header1) + 1; header_loc++)
-    {
+    for (header_loc = 0; header_loc < strlen(header1) + 1; header_loc++) {
         c = getc(f);
-        if(c != header1[header_loc]) {
+        if (c != header1[header_loc]) {
             break;
         }
     }
-    if(header_loc == strlen(header1) + 1) // we found it
-    {
+    if (header_loc == strlen(header1) + 1) { // we found it
         unsigned short remaining_header_len;
         if (fread(&remaining_header_len,
                   sizeof(remaining_header_len), 1, f) != 1 ||
@@ -91,9 +83,8 @@ void TransducerHeader::skip_hfst3_header(FILE * f)
             HFST_THROW_MESSAGE(HeaderParsingException,
                                "Found broken HFST3 header\n");
         }
-        char * headervalue = new char[remaining_header_len];
-        if (fread(headervalue, remaining_header_len, 1, f) != 1)
-        {
+        char* headervalue = new char[remaining_header_len];
+        if (fread(headervalue, remaining_header_len, 1, f) != 1) {
             HFST_THROW_MESSAGE(HeaderParsingException,
                                "HFST3 header ended unexpectedly\n");
         }
@@ -113,36 +104,32 @@ void TransducerHeader::skip_hfst3_header(FILE * f)
                     "hfst-optimized-lookup\n");
             }
         }
-    } else // nope. put back what we've taken
-    {
+    } else { // nope. put back what we've taken
         ungetc(c, f); // first the non-matching character
-        for(int i = header_loc - 1; i>=0; i--) {
+        for (int i = header_loc - 1; i >= 0; i--) {
             // then the characters that did match (if any)
             ungetc(header1[i], f);
         }
     }
 }
 
-void TransducerHeader::skip_hfst3_header(char ** raw)
+void TransducerHeader::skip_hfst3_header(char** raw)
 {
     const char* header1 = "HFST";
     unsigned int header_loc = 0; // how much of the header has been found
 
-    for(header_loc = 0; header_loc < strlen(header1) + 1; header_loc++)
-    {
-        if(**raw != header1[header_loc]) {
+    for (header_loc = 0; header_loc < strlen(header1) + 1; header_loc++) {
+        if (**raw != header1[header_loc]) {
             break;
         }
         ++(*raw);
     }
-    if(header_loc == strlen(header1) + 1) // we found it
-    {
-        unsigned short remaining_header_len = *((unsigned short *) *raw);
+    if (header_loc == strlen(header1) + 1) { // we found it
+        unsigned short remaining_header_len = *((unsigned short*) *raw);
         (*raw) += sizeof(unsigned short) + 1 + remaining_header_len;
-    } else // nope. put back what we've taken
-    {
+    } else { // nope. put back what we've taken
         --(*raw); // first the non-matching character
-        for(int i = header_loc - 1; i>=0; i--) {
+        for (int i = header_loc - 1; i >= 0; i--) {
             // then the characters that did match (if any)
             --(*raw);
         }
@@ -153,31 +140,31 @@ TransducerHeader::TransducerHeader(FILE* f)
 {
     skip_hfst3_header(f); // skip header iff it is present
     /* The following conditional clause does all the numerical reads
-       and throws an exception if any fails to return 1 */
+     * and throws an exception if any fails to return 1 */
     if (fread(&number_of_input_symbols,
-              sizeof(SymbolNumber),1,f) != 1||
+              sizeof(SymbolNumber), 1, f) != 1 ||
         fread(&number_of_symbols,
-              sizeof(SymbolNumber),1,f) != 1||
+              sizeof(SymbolNumber), 1, f) != 1 ||
         fread(&size_of_transition_index_table,
-              sizeof(TransitionTableIndex),1,f) != 1||
+              sizeof(TransitionTableIndex), 1, f) != 1 ||
         fread(&size_of_transition_target_table,
-              sizeof(TransitionTableIndex),1,f) != 1||
+              sizeof(TransitionTableIndex), 1, f) != 1 ||
         fread(&number_of_states,
-              sizeof(TransitionTableIndex),1,f) != 1||
+              sizeof(TransitionTableIndex), 1, f) != 1 ||
         fread(&number_of_transitions,
-              sizeof(TransitionTableIndex),1,f) != 1) {
+              sizeof(TransitionTableIndex), 1, f) != 1) {
         HFST_THROW_MESSAGE(HeaderParsingException,
                            "Header ended unexpectedly\n");
     }
-    read_property(weighted,f);
-    read_property(deterministic,f);
-    read_property(input_deterministic,f);
-    read_property(minimized,f);
-    read_property(cyclic,f);
-    read_property(has_epsilon_epsilon_transitions,f);
-    read_property(has_input_epsilon_transitions,f);
-    read_property(has_input_epsilon_cycles,f);
-    read_property(has_unweighted_input_epsilon_cycles,f);
+    read_property(weighted, f);
+    read_property(deterministic, f);
+    read_property(input_deterministic, f);
+    read_property(minimized, f);
+    read_property(cyclic, f);
+    read_property(has_epsilon_epsilon_transitions, f);
+    read_property(has_input_epsilon_transitions, f);
+    read_property(has_input_epsilon_cycles, f);
+    read_property(has_unweighted_input_epsilon_cycles, f);
 }
 
 TransducerHeader::TransducerHeader(char** raw)
@@ -195,38 +182,38 @@ TransducerHeader::TransducerHeader(char** raw)
     (*raw) += sizeof(TransitionTableIndex);
     number_of_transitions = *(TransitionTableIndex*) *raw;
     (*raw) += sizeof(TransitionTableIndex);
-    read_property(weighted,raw);
-    read_property(deterministic,raw);
-    read_property(input_deterministic,raw);
-    read_property(minimized,raw);
-    read_property(cyclic,raw);
-    read_property(has_epsilon_epsilon_transitions,raw);
-    read_property(has_input_epsilon_transitions,raw);
-    read_property(has_input_epsilon_cycles,raw);
-    read_property(has_unweighted_input_epsilon_cycles,raw);
+    read_property(weighted, raw);
+    read_property(deterministic, raw);
+    read_property(input_deterministic, raw);
+    read_property(minimized, raw);
+    read_property(cyclic, raw);
+    read_property(has_epsilon_epsilon_transitions, raw);
+    read_property(has_input_epsilon_transitions, raw);
+    read_property(has_input_epsilon_cycles, raw);
+    read_property(has_unweighted_input_epsilon_cycles, raw);
 }
 
 SymbolNumber
 TransducerHeader::symbol_count()
 {
-    return number_of_symbols; 
+    return number_of_symbols;
 }
 
 SymbolNumber
 TransducerHeader::input_symbol_count()
 {
-    return number_of_input_symbols; 
+    return number_of_input_symbols;
 }
 TransitionTableIndex
 TransducerHeader::index_table_size(void)
 {
-    return size_of_transition_index_table; 
+    return size_of_transition_index_table;
 }
 
-TransitionTableIndex 
+TransitionTableIndex
 TransducerHeader::target_table_size()
 {
-    return size_of_transition_target_table; 
+    return size_of_transition_target_table;
 }
 
 bool
@@ -258,7 +245,7 @@ TransducerHeader::probe_flag(HeaderFlag flag)
 bool
 FlagDiacriticOperation::isFlag() const
 {
-    return feature != NO_SYMBOL; 
+    return feature != NO_SYMBOL;
 }
 
 FlagDiacriticOperator
@@ -281,9 +268,9 @@ FlagDiacriticOperation::Value() const
 }
 
 
-void TransducerAlphabet::read(FILE * f, SymbolNumber number_of_symbols)
+void TransducerAlphabet::read(FILE* f, SymbolNumber number_of_symbols)
 {
-    char * line = (char *) malloc(MAX_SYMBOL_BYTES);
+    char* line = (char*) malloc(MAX_SYMBOL_BYTES);
     std::map<std::string, SymbolNumber> feature_bucket;
     std::map<std::string, ValueNumber> value_bucket;
     value_bucket[std::string()] = 0; // empty value = neutral
@@ -300,7 +287,7 @@ void TransducerAlphabet::read(FILE * f, SymbolNumber number_of_symbols)
     }
 
     for (SymbolNumber k = 1; k < number_of_symbols; ++k) {
-        char * sym = line;
+        char* sym = line;
         while ( (byte = fgetc(f)) != 0 ) {
             if (byte == EOF) {
                 HFST_THROW(AlphabetParsingException);
@@ -323,19 +310,20 @@ void TransducerAlphabet::read(FILE * f, SymbolNumber number_of_symbols)
                 case 'C': op = C; break;
                 case 'U': op = U; break;
                 }
-                char * c = line;
-                for (c +=3; *c != '.' && *c != '@'; c++) { feat.append(c,1); }
-                if (*c == '.')
-                {
-                    for (++c; *c != '@'; c++) { val.append(c,1); }
+                char* c = line;
+                for (c += 3; *c != '.' && *c != '@'; c++) {
+                    feat.append(c, 1);
                 }
-                if (feature_bucket.count(feat) == 0)
-                {
+                if (*c == '.') {
+                    for (++c; *c != '@'; c++) {
+                        val.append(c, 1);
+                    }
+                }
+                if (feature_bucket.count(feat) == 0) {
                     feature_bucket[feat] = feat_num;
                     ++feat_num;
                 }
-                if (value_bucket.count(val) == 0)
-                {
+                if (value_bucket.count(val) == 0) {
                     value_bucket[val] = val_num;
                     ++val_num;
                 }
@@ -369,7 +357,7 @@ void TransducerAlphabet::read(FILE * f, SymbolNumber number_of_symbols)
     flag_state_size = feature_bucket.size();
 }
 
-void TransducerAlphabet::read(char ** raw, SymbolNumber number_of_symbols)
+void TransducerAlphabet::read(char** raw, SymbolNumber number_of_symbols)
 {
     std::map<std::string, SymbolNumber> feature_bucket;
     std::map<std::string, ValueNumber> value_bucket;
@@ -396,19 +384,20 @@ void TransducerAlphabet::read(char ** raw, SymbolNumber number_of_symbols)
                 case 'C': op = C; break;
                 case 'U': op = U; break;
                 }
-                char * c = *raw;
-                for (c +=3; *c != '.' && *c != '@'; c++) { feat.append(c,1); }
-                if (*c == '.')
-                {
-                    for (++c; *c != '@'; c++) { val.append(c,1); }
+                char* c = *raw;
+                for (c += 3; *c != '.' && *c != '@'; c++) {
+                    feat.append(c, 1);
                 }
-                if (feature_bucket.count(feat) == 0)
-                {
+                if (*c == '.') {
+                    for (++c; *c != '@'; c++) {
+                        val.append(c, 1);
+                    }
+                }
+                if (feature_bucket.count(feat) == 0) {
                     feature_bucket[feat] = feat_num;
                     ++feat_num;
                 }
-                if (value_bucket.count(val) == 0)
-                {
+                if (value_bucket.count(val) == 0) {
                     value_bucket[val] = val_num;
                     ++val_num;
                 }
@@ -446,7 +435,7 @@ void TransducerAlphabet::read(char ** raw, SymbolNumber number_of_symbols)
     flag_state_size = feature_bucket.size();
 }
 
-TransducerAlphabet::TransducerAlphabet(FILE* f, SymbolNumber number_of_symbols):
+TransducerAlphabet::TransducerAlphabet(FILE* f, SymbolNumber number_of_symbols) :
     unknown_symbol(NO_SYMBOL),
     identity_symbol(NO_SYMBOL),
     orig_symbol_count(number_of_symbols)
@@ -455,7 +444,7 @@ TransducerAlphabet::TransducerAlphabet(FILE* f, SymbolNumber number_of_symbols):
 }
 
 TransducerAlphabet::TransducerAlphabet(char** raw,
-                                       SymbolNumber number_of_symbols):
+                                       SymbolNumber number_of_symbols) :
     unknown_symbol(NO_SYMBOL),
     identity_symbol(NO_SYMBOL),
     orig_symbol_count(number_of_symbols)
@@ -469,7 +458,7 @@ void TransducerAlphabet::add_symbol(std::string & sym)
     kt.push_back(sym);
 }
 
-void TransducerAlphabet::add_symbol(char * sym)
+void TransducerAlphabet::add_symbol(char* sym)
 {
     std::string s(sym);
     add_symbol(s);
@@ -478,7 +467,7 @@ void TransducerAlphabet::add_symbol(char * sym)
 KeyTable*
 TransducerAlphabet::get_key_table()
 {
-    return &kt; 
+    return &kt;
 }
 
 OperationMap*
@@ -527,71 +516,67 @@ TransducerAlphabet::is_flag(SymbolNumber symbol)
     return operations.count(symbol) == 1;
 }
 
-void IndexTable::read(FILE * f,
+void IndexTable::read(FILE* f,
                       TransitionTableIndex number_of_table_entries)
 {
-    size_t table_size = number_of_table_entries*TransitionIndex::SIZE;
-    indices = (char*)(malloc(table_size));
-    if (fread(indices,table_size, 1, f) != 1) {
+    size_t table_size = number_of_table_entries * TransitionIndex::SIZE;
+    indices = (char*) (malloc(table_size));
+    if (fread(indices, table_size, 1, f) != 1) {
         HFST_THROW(IndexTableReadingException);
     }
 }
 
-void IndexTable::read(char ** raw,
+void IndexTable::read(char** raw,
                       TransitionTableIndex number_of_table_entries)
 {
-    size_t table_size = number_of_table_entries*TransitionIndex::SIZE;
-    indices = (char*)(malloc(table_size));
-    memcpy((void *) indices, (const void *) *raw, table_size);
+    size_t table_size = number_of_table_entries * TransitionIndex::SIZE;
+    indices = (char*) (malloc(table_size));
+    memcpy((void*) indices, (const void*) *raw, table_size);
     (*raw) += table_size;
 }
 
-void TransitionTable::read(FILE * f,
+void TransitionTable::read(FILE* f,
                            TransitionTableIndex number_of_table_entries)
 {
-    size_t table_size = number_of_table_entries*Transition::SIZE;
-    transitions = (char*)(malloc(table_size));
+    size_t table_size = number_of_table_entries * Transition::SIZE;
+    transitions = (char*) (malloc(table_size));
     if (fread(transitions, table_size, 1, f) != 1) {
         HFST_THROW(TransitionTableReadingException);
     }
 }
 
-void TransitionTable::read(char ** raw,
+void TransitionTable::read(char** raw,
                            TransitionTableIndex number_of_table_entries)
 {
-    size_t table_size = number_of_table_entries*Transition::SIZE;
-    transitions = (char*)(malloc(table_size));
-    memcpy((void *) transitions, (const void *) *raw, table_size);
+    size_t table_size = number_of_table_entries * Transition::SIZE;
+    transitions = (char*) (malloc(table_size));
+    memcpy((void*) transitions, (const void*) *raw, table_size);
     (*raw) += table_size;
 }
 
-void LetterTrie::add_string(const char * p, SymbolNumber symbol_key)
+void LetterTrie::add_string(const char* p, SymbolNumber symbol_key)
 {
-    if (*(p+1) == 0)
-    {
-        symbols[(unsigned char)(*p)] = symbol_key;
+    if (*(p + 1) == 0) {
+        symbols[(unsigned char) (*p)] = symbol_key;
         return;
     }
-    if (letters[(unsigned char)(*p)] == NULL)
-    {
-        letters[(unsigned char)(*p)] = new LetterTrie();
+    if (letters[(unsigned char) (*p)] == NULL) {
+        letters[(unsigned char) (*p)] = new LetterTrie();
     }
-    letters[(unsigned char)(*p)]->add_string(p+1,symbol_key);
+    letters[(unsigned char) (*p)]->add_string(p + 1, symbol_key);
 }
 
-SymbolNumber LetterTrie::find_key(char ** p)
+SymbolNumber LetterTrie::find_key(char** p)
 {
-    const char * old_p = *p;
+    const char* old_p = *p;
     ++(*p);
-    if (letters[(unsigned char)(*old_p)] == NULL)
-    {
-        return symbols[(unsigned char)(*old_p)];
+    if (letters[(unsigned char) (*old_p)] == NULL) {
+        return symbols[(unsigned char) (*old_p)];
     }
-    SymbolNumber s = letters[(unsigned char)(*old_p)]->find_key(p);
-    if (s == NO_SYMBOL)
-    {
+    SymbolNumber s = letters[(unsigned char) (*old_p)]->find_key(p);
+    if (s == NO_SYMBOL) {
         --(*p);
-        return symbols[(unsigned char)(*old_p)];
+        return symbols[(unsigned char) (*old_p)];
     }
     return s;
 }
@@ -599,29 +584,26 @@ SymbolNumber LetterTrie::find_key(char ** p)
 LetterTrie::~LetterTrie()
 {
     for (LetterTrieVector::iterator i = letters.begin();
-         i != letters.end(); ++i)
-    {
-        if (*i)
-        { 
+         i != letters.end(); ++i) {
+        if (*i) {
             delete *i;
         }
     }
 }
 
-Encoder::Encoder(KeyTable * kt, SymbolNumber number_of_input_symbols):
-    ascii_symbols(UCHAR_MAX,NO_SYMBOL)
+Encoder::Encoder(KeyTable* kt, SymbolNumber number_of_input_symbols) :
+    ascii_symbols(UCHAR_MAX, NO_SYMBOL)
 {
     read_input_symbols(kt, number_of_input_symbols);
 }
 
-void Encoder::read_input_symbol(const char * s, const int s_num)
+void Encoder::read_input_symbol(const char* s, const int s_num)
 {
     if (strlen(s) == 0) { // ignore empty strings
         return;
     }
-    if ((strlen(s) == 1) && (unsigned char)(*s) <= 127)
-    {
-        ascii_symbols[(unsigned char)(*s)] = s_num;
+    if ((strlen(s) == 1) && (unsigned char) (*s) <= 127) {
+        ascii_symbols[(unsigned char) (*s)] = s_num;
     }
     letters.add_string(s, s_num);
 }
@@ -631,12 +613,11 @@ void Encoder::read_input_symbol(std::string const & s, const int s_num)
     read_input_symbol(s.c_str(), s_num);
 }
 
-void Encoder::read_input_symbols(KeyTable * kt,
+void Encoder::read_input_symbols(KeyTable* kt,
                                  SymbolNumber number_of_input_symbols)
 {
-    for (SymbolNumber k = 0; k < number_of_input_symbols; ++k)
-    {
-        const char * p = kt->at(k).c_str();
+    for (SymbolNumber k = 0; k < number_of_input_symbols; ++k) {
+        const char* p = kt->at(k).c_str();
         read_input_symbol(p, k);
     }
 }
@@ -647,11 +628,11 @@ TransitionIndex::target() const
     return first_transition_index;
 }
 
-bool 
-TransitionIndex::final(void) const
+bool
+TransitionIndex::final (void) const
 {
     return input_symbol == NO_SYMBOL &&
-        first_transition_index != NO_TABLE_INDEX;
+           first_transition_index != NO_TABLE_INDEX;
 }
 
 Weight
@@ -672,7 +653,7 @@ TransitionIndex::get_input(void) const
     return input_symbol;
 }
 
-TransitionTableIndex 
+TransitionTableIndex
 Transition::target(void) const
 {
     return target_index;
@@ -697,23 +678,23 @@ Transition::get_weight(void) const
 }
 
 bool
-Transition::final(void) const
+Transition::final (void) const
 {
     return input_symbol == NO_SYMBOL &&
-        output_symbol == NO_SYMBOL &&
-        target_index == 1;
+           output_symbol == NO_SYMBOL &&
+           target_index == 1;
 }
 
 IndexTable::IndexTable(FILE* f,
-                       TransitionTableIndex number_of_table_entries):
+                       TransitionTableIndex number_of_table_entries) :
     indices(NULL),
     size(number_of_table_entries)
 {
     read(f, number_of_table_entries);
 }
-    
-IndexTable::IndexTable(char ** raw,
-                       TransitionTableIndex number_of_table_entries):
+
+IndexTable::IndexTable(char** raw,
+                       TransitionTableIndex number_of_table_entries) :
     indices(NULL),
     size(number_of_table_entries)
 {
@@ -731,7 +712,7 @@ SymbolNumber
 IndexTable::input_symbol(TransitionTableIndex i) const
 {
     if (i < size) {
-        return hfst_deref((SymbolNumber *)
+        return hfst_deref((SymbolNumber*)
                           (indices + TransitionIndex::SIZE * i));
     } else {
         return NO_SYMBOL;
@@ -742,7 +723,7 @@ TransitionTableIndex
 IndexTable::target(TransitionTableIndex i) const
 {
     if (i < size) {
-        return hfst_deref((TransitionTableIndex *) 
+        return hfst_deref((TransitionTableIndex*)
                           (indices + TransitionIndex::SIZE * i +
                            sizeof(SymbolNumber)));
     } else {
@@ -751,7 +732,7 @@ IndexTable::target(TransitionTableIndex i) const
 }
 
 bool
-IndexTable::final(TransitionTableIndex i) const
+IndexTable::final (TransitionTableIndex i) const
 {
     return input_symbol(i) == NO_SYMBOL && target(i) != NO_TABLE_INDEX;
 }
@@ -760,7 +741,7 @@ Weight
 IndexTable::final_weight(TransitionTableIndex i) const
 {
     if (i < size) {
-        return hfst_deref((Weight *)
+        return hfst_deref((Weight*)
                           (indices + TransitionIndex::SIZE * i +
                            sizeof(SymbolNumber)));
     } else {
@@ -768,16 +749,16 @@ IndexTable::final_weight(TransitionTableIndex i) const
     }
 }
 
-TransitionTable::TransitionTable(FILE * f,
-                                 TransitionTableIndex transition_count):
+TransitionTable::TransitionTable(FILE* f,
+                                 TransitionTableIndex transition_count) :
     transitions(NULL),
     size(transition_count)
 {
     read(f, transition_count);
 }
-  
-TransitionTable::TransitionTable(char ** raw,
-                                 TransitionTableIndex transition_count):
+
+TransitionTable::TransitionTable(char** raw,
+                                 TransitionTableIndex transition_count) :
     transitions(NULL),
     size(transition_count)
 {
@@ -795,7 +776,7 @@ SymbolNumber
 TransitionTable::input_symbol(TransitionTableIndex i) const
 {
     if (i < size) {
-        return hfst_deref((SymbolNumber *)
+        return hfst_deref((SymbolNumber*)
                           (transitions + Transition::SIZE * i));
     } else {
         return NO_SYMBOL;
@@ -806,7 +787,7 @@ SymbolNumber
 TransitionTable::output_symbol(TransitionTableIndex i) const
 {
     if (i < size) {
-        return hfst_deref((SymbolNumber *)
+        return hfst_deref((SymbolNumber*)
                           (transitions + Transition::SIZE * i +
                            sizeof(SymbolNumber)));
     } else {
@@ -818,9 +799,9 @@ TransitionTableIndex
 TransitionTable::target(TransitionTableIndex i) const
 {
     if (i < size) {
-        return hfst_deref((TransitionTableIndex *)
+        return hfst_deref((TransitionTableIndex*)
                           (transitions + Transition::SIZE * i +
-                           2*sizeof(SymbolNumber)));
+                           2 * sizeof(SymbolNumber)));
     } else {
         return NO_TABLE_INDEX;
     }
@@ -830,9 +811,9 @@ Weight
 TransitionTable::weight(TransitionTableIndex i) const
 {
     if (i < size) {
-        return hfst_deref((Weight *)
+        return hfst_deref((Weight*)
                           (transitions + Transition::SIZE * i +
-                           2*sizeof(SymbolNumber) +
+                           2 * sizeof(SymbolNumber) +
                            sizeof(TransitionTableIndex)));
     } else {
         return INFINITE_WEIGHT;
@@ -840,20 +821,19 @@ TransitionTable::weight(TransitionTableIndex i) const
 }
 
 bool
-TransitionTable::final(TransitionTableIndex i) const
+TransitionTable::final (TransitionTableIndex i) const
 {
     return input_symbol(i) == NO_SYMBOL &&
-        output_symbol(i) == NO_SYMBOL &&
-        target(i) == 1;
+           output_symbol(i) == NO_SYMBOL &&
+           target(i) == 1;
 }
 
-SymbolNumber Encoder::find_key(char ** p)
+SymbolNumber Encoder::find_key(char** p)
 {
-    if (ascii_symbols[(unsigned char)(**p)] == NO_SYMBOL)
-    {
+    if (ascii_symbols[(unsigned char) (**p)] == NO_SYMBOL) {
         return letters.find_key(p);
     }
-    SymbolNumber s = ascii_symbols[(unsigned char)(**p)];
+    SymbolNumber s = ascii_symbols[(unsigned char) (**p)];
     ++(*p);
     return s;
 }

--- a/hfst-ol.h
+++ b/hfst-ol.h
@@ -64,15 +64,15 @@ const TransitionTableIndex TARGET_TABLE = 2147483648u;
 
 // the flag diacritic operators as given in
 // Beesley & Karttunen, Finite State Morphology (U of C Press 2003)
-enum FlagDiacriticOperator {P, N, R, D, C, U};
+enum FlagDiacriticOperator { P, N, R, D, C, U };
 
-enum HeaderFlag {Weighted, Deterministic, Input_deterministic, Minimized,
-                 Cyclic, Has_epsilon_epsilon_transitions,
-                 Has_input_epsilon_transitions, Has_input_epsilon_cycles,
-                 Has_unweighted_input_epsilon_cycles};
+enum HeaderFlag { Weighted, Deterministic, Input_deterministic, Minimized,
+                  Cyclic, Has_epsilon_epsilon_transitions,
+                  Has_input_epsilon_transitions, Has_input_epsilon_cycles,
+                  Has_unweighted_input_epsilon_cycles };
 
 // Utility function for dealing with raw memory
-void skip_c_string(char ** raw);
+void skip_c_string(char** raw);
 
 //! Internal class for Transducer processing.
 
@@ -97,19 +97,19 @@ private:
     bool has_input_epsilon_transitions;
     bool has_input_epsilon_cycles;
     bool has_unweighted_input_epsilon_cycles;
-    void read_property(bool &property, FILE * f);
-    void read_property(bool &property, char ** raw);
-    void skip_hfst3_header(FILE * f);
-    void skip_hfst3_header(char ** f);
+    void read_property(bool &property, FILE* f);
+    void read_property(bool &property, char** raw);
+    void skip_hfst3_header(FILE* f);
+    void skip_hfst3_header(char** f);
 
 public:
     //!
     //! @brief read header from file @a f
-    TransducerHeader(FILE * f);
+    TransducerHeader(FILE* f);
 
     //!
     //! read header from raw memory data @a raw
-    TransducerHeader(char ** raw);
+    TransducerHeader(char** raw);
     //!
     //! count symbols
     SymbolNumber symbol_count(void);
@@ -137,27 +137,31 @@ private:
     const SymbolNumber feature;
     const ValueNumber value;
 public:
-    //! 
+    //!
     //! Construct flag diacritic of from \@ @a op . @a feat . @a val \@.
     FlagDiacriticOperation(const FlagDiacriticOperator op,
                            const SymbolNumber feat,
-                           const ValueNumber val):
-        operation(op), feature(feat), value(val) {}
+                           const ValueNumber val) :
+        operation(op), feature(feat), value(val)
+    {
+    }
 
     // dummy constructor
-    FlagDiacriticOperation():
-        operation(P), feature(NO_SYMBOL), value(0) {}
-  
+    FlagDiacriticOperation() :
+        operation(P), feature(NO_SYMBOL), value(0)
+    {
+    }
+
     //!
     //! check if flag
     bool isFlag(void) const;
     //!
     //! Operation something I don't understand really.
     FlagDiacriticOperator Operation(void) const;
-    //! 
+    //!
     //! No clue
     SymbolNumber Feature(void) const;
-    //! 
+    //!
     //! Not a slightest idea
     ValueNumber Value(void) const;
 
@@ -176,31 +180,31 @@ private:
     SymbolNumber flag_state_size;
     SymbolNumber orig_symbol_count;
     StringSymbolMap string_to_symbol;
-    void process_symbol(char * line);
-    
-    void read(FILE * f, SymbolNumber number_of_symbols);
-    void read(char ** raw, SymbolNumber number_of_symbols);
-    
+    void process_symbol(char* line);
+
+    void read(FILE* f, SymbolNumber number_of_symbols);
+    void read(char** raw, SymbolNumber number_of_symbols);
+
 public:
-    //! 
+    //!
     //! read alphabets from file @a f
-    TransducerAlphabet(FILE *f, SymbolNumber number_of_symbols);
-    //! 
+    TransducerAlphabet(FILE* f, SymbolNumber number_of_symbols);
+    //!
     //! read alphabes from raw data @a raw
-    TransducerAlphabet(char ** raw, SymbolNumber number_of_symbols);
-    
+    TransducerAlphabet(char** raw, SymbolNumber number_of_symbols);
+
     void add_symbol(std::string & sym);
-    void add_symbol(char * sym);
+    void add_symbol(char* sym);
     //!
     //! get alphabet's keytable mapping
-    KeyTable * get_key_table(void);
-    //! 
+    KeyTable* get_key_table(void);
+    //!
     //! get flag operation map stuff
-    OperationMap * get_operation_map(void);
+    OperationMap* get_operation_map(void);
     //!
     //! get state's size
     SymbolNumber get_state_size(void);
-    //! 
+    //!
     //! get position of unknown symbol
     SymbolNumber get_unknown(void) const;
     SymbolNumber get_identity(void) const;
@@ -208,9 +212,9 @@ public:
     SymbolNumber get_orig_symbol_count(void) const;
     //!
     //! get mapping from strings to symbols
-    StringSymbolMap * get_string_to_symbol(void);
+    StringSymbolMap* get_string_to_symbol(void);
     bool has_string(std::string const & s) const;
-    //! 
+    //!
     //! get if given symbol is a flag
     bool is_flag(SymbolNumber symbol);
 };
@@ -228,16 +232,17 @@ private:
     SymbolVector symbols;
 
 public:
-    LetterTrie(void):
-    letters(UCHAR_MAX, static_cast<LetterTrie*>(NULL)),
-    symbols(UCHAR_MAX,NO_SYMBOL)
-        {}
-    //! 
+    LetterTrie(void) :
+        letters(UCHAR_MAX, static_cast<LetterTrie*>(NULL)),
+        symbols(UCHAR_MAX, NO_SYMBOL)
+    {
+    }
+    //!
     //! add a string to alphabets with a key
-    void add_string(const char * p,SymbolNumber symbol_key);
+    void add_string(const char* p, SymbolNumber symbol_key);
     //!
     //! find a key for string or add it
-    SymbolNumber find_key(char ** p);
+    SymbolNumber find_key(char** p);
     ~LetterTrie();
 };
 
@@ -250,14 +255,14 @@ private:
     LetterTrie letters;
     SymbolVector ascii_symbols;
 
-    void read_input_symbols(KeyTable * kt, SymbolNumber number_of_input_symbols);
+    void read_input_symbols(KeyTable* kt, SymbolNumber number_of_input_symbols);
 
 public:
     //!
-    //! create encoder from keytable 
-    Encoder(KeyTable * kt, SymbolNumber number_of_input_symbols);
-    SymbolNumber find_key(char ** p);
-    void read_input_symbol(const char * s, const int s_num);
+    //! create encoder from keytable
+    Encoder(KeyTable* kt, SymbolNumber number_of_input_symbols);
+    SymbolNumber find_key(char** p);
+    void read_input_symbol(const char* s, const int s_num);
     void read_input_symbol(std::string const & s, const int s_num);
 };
 
@@ -271,27 +276,28 @@ class TransitionIndex
 protected:
     SymbolNumber input_symbol; //!< transition's input symbol
     TransitionTableIndex first_transition_index; //!< first transition location
-  
+
 public:
-  
+
     //!
     //! Each TransitionIndex has an input symbol and a target index.
-    static const size_t SIZE = 
+    static const size_t SIZE =
         sizeof(SymbolNumber) + sizeof(TransitionTableIndex);
 
     //!
     //! Create transition index for symbol
     TransitionIndex(const SymbolNumber input,
-                    const TransitionTableIndex first_transition):
+                    const TransitionTableIndex first_transition) :
         input_symbol(input),
         first_transition_index(first_transition)
-        {}
+    {
+    }
     //!
     //! return target of transition
     TransitionTableIndex target(void) const;
     //!
     //! whether it's final state
-    bool final(void) const;
+    bool final (void) const;
     //!
     //! retrieve final weight
     Weight final_weight(void) const;
@@ -313,9 +319,9 @@ protected:
 
 public:
 
-    //! Each transition has an input symbol, an output symbol and 
+    //! Each transition has an input symbol, an output symbol and
     //! a target index.
-    static const size_t SIZE = 
+    static const size_t SIZE =
         2 * sizeof(SymbolNumber) + sizeof(TransitionTableIndex) + sizeof(Weight);
 
     //!
@@ -323,21 +329,23 @@ public:
     Transition(const SymbolNumber input,
                const SymbolNumber output,
                const TransitionTableIndex target,
-               const Weight w):
+               const Weight w) :
         input_symbol(input),
         output_symbol(output),
         target_index(target),
         transition_weight(w)
-        {}
+    {
+    }
 
-    Transition():
+    Transition() :
         input_symbol(NO_SYMBOL),
         output_symbol(NO_SYMBOL),
         target_index(NO_TABLE_INDEX),
         transition_weight(INFINITE_WEIGHT)
-        {}
+    {
+    }
 
-    //! 
+    //!
     //! get transitions target
     TransitionTableIndex target(void) const;
     //!
@@ -351,7 +359,7 @@ public:
     Weight get_weight(void) const;
     //!
     //! whether transition is final
-    bool final(void) const;
+    bool final (void) const;
 };
 
 //! Internal class for Transducer processing.
@@ -360,22 +368,22 @@ public:
 class IndexTable
 {
 private:
-    char * indices;
-  
-    void read(FILE * f,
+    char* indices;
+
+    void read(FILE* f,
               TransitionTableIndex number_of_table_entries);
-    void read(char ** raw,
+    void read(char** raw,
               TransitionTableIndex number_of_table_entries);
     TransitionTableIndex size;
 
 public:
     //!
     //! read index table from file @a f.
-    IndexTable(FILE * f,
+    IndexTable(FILE* f,
                TransitionTableIndex number_of_table_entries);
     //!
     //! read index table from raw data @a raw.
-    IndexTable(char ** raw,
+    IndexTable(char** raw,
                TransitionTableIndex number_of_table_entries);
     ~IndexTable(void);
     //!
@@ -384,10 +392,10 @@ public:
     //!
     //! target state location for the index
     TransitionTableIndex target(TransitionTableIndex i) const;
-    //! 
+    //!
     //! whether it's final transition
-    bool final(TransitionTableIndex i) const;
-    //! 
+    bool final (TransitionTableIndex i) const;
+    //!
     //! transition's weight
     Weight final_weight(TransitionTableIndex i) const;
 };
@@ -400,31 +408,31 @@ class TransitionTable
 protected:
     //!
     //! raw transition data
-    char * transitions;
- 
+    char* transitions;
+
     //!
     //! read known amount of transitions from file @a f
-    void read(FILE * f,
+    void read(FILE* f,
               TransitionTableIndex number_of_table_entries);
     //! read known amount of transitions from raw dara @a data
-    void read(char ** raw,
+    void read(char** raw,
               TransitionTableIndex number_of_table_entries);
     TransitionTableIndex size;
 public:
-    //! 
+    //!
     //! read transition table from file @a f
-    TransitionTable(FILE * f,
+    TransitionTable(FILE* f,
                     TransitionTableIndex transition_count);
     //!
     //! read transition table from raw data @a raw
-    TransitionTable(char ** raw,
+    TransitionTable(char** raw,
                     TransitionTableIndex transition_count);
 
     ~TransitionTable(void);
-    //! 
+    //!
     //! transition's input symbol
     SymbolNumber input_symbol(TransitionTableIndex i) const;
-    //! 
+    //!
     //! transition's output symbol
     SymbolNumber output_symbol(TransitionTableIndex i) const;
     //!
@@ -435,7 +443,7 @@ public:
     Weight weight(TransitionTableIndex i) const;
     //!
     //! whether it's final
-    bool final(TransitionTableIndex i) const;
+    bool final (TransitionTableIndex i) const;
 
 
 };
@@ -449,5 +457,5 @@ void debug_print(printable p)
 }
 
 } // namespace hfst_ol
-    
+
 #endif // HFST_OSPELL_HFST_OL_H_

--- a/main-cicling.cc
+++ b/main-cicling.cc
@@ -1,23 +1,23 @@
 /*
-  
-  Copyright 2009 University of Helsinki
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-  http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  
-*/
+ *
+ * Copyright 2009 University of Helsinki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /*
-  This is a toy commandline utility for testing spellers on standard io.
+ * This is a toy commandline utility for testing spellers on standard io.
  */
 
 #include "ospell.h"
@@ -32,30 +32,30 @@
 bool print_usage(void)
 {
     std::cerr <<
-    "\n" <<
-    "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
-    "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
-    "print corrected output\n" <<
-    "\n" <<
-    "  -h, --help                  Print this help message\n" <<
-    "  -V, --version               Print version information\n" <<
-    "  -v, --verbose               Be verbose\n" <<
-    "  -q, --quiet                 Don't be verbose (default)\n" <<
-    "  -s, --silent                Same as quiet\n" <<
-    "\n" <<
-    "\n" <<
-    "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
-    "\n";
+        "\n" <<
+        "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
+        "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
+        "print corrected output\n" <<
+        "\n" <<
+        "  -h, --help                  Print this help message\n" <<
+        "  -V, --version               Print version information\n" <<
+        "  -v, --verbose               Be verbose\n" <<
+        "  -q, --quiet                 Don't be verbose (default)\n" <<
+        "  -s, --silent                Same as quiet\n" <<
+        "\n" <<
+        "\n" <<
+        "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
+        "\n";
     return true;
 }
 
 bool print_version(void)
 {
     std::cerr <<
-    "\n" <<
-    PACKAGE_STRING << std::endl <<
-    __DATE__ << " " __TIME__ << std::endl <<
-    "copyright (C) 2009 University of Helsinki\n";
+        "\n" <<
+        PACKAGE_STRING << std::endl <<
+        __DATE__ << " " __TIME__ << std::endl <<
+        "copyright (C) 2009 University of Helsinki\n";
     return true;
 }
 
@@ -65,28 +65,27 @@ bool print_short_help(void)
     return true;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
 
-    FILE * mutator_file = NULL;
-    FILE * lexicon_file = NULL;
-    
+    FILE* mutator_file = NULL;
+    FILE* lexicon_file = NULL;
+
     int c;
     bool verbose = false;
 
-    while (true) 
-      {
+    while (true) {
         static struct option long_options[] =
         {
-        // first the hfst-mandated options
-        {"help",         no_argument,       0, 'h'},
-        {"version",      no_argument,       0, 'V'},
-        {"verbose",      no_argument,       0, 'v'},
-        {"quiet",        no_argument,       0, 'q'},
-        {"silent",       no_argument,       0, 's'},
-        {0,              0,                 0,  0 }
+            // first the hfst-mandated options
+            { "help",         no_argument,       0, 'h' },
+            { "version",      no_argument,       0, 'V' },
+            { "verbose",      no_argument,       0, 'v' },
+            { "quiet",        no_argument,       0, 'q' },
+            { "silent",       no_argument,       0, 's' },
+            { 0,              0,                 0,  0 }
         };
-      
+
         int option_index = 0;
         c = getopt_long(argc, argv, "hVvqs", long_options, &option_index);
 
@@ -98,20 +97,20 @@ int main(int argc, char **argv)
             print_usage();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'V':
             print_version();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'v':
             verbose = true;
             break;
-          
+
         case 'q': // fallthrough
         case 's':
             break;
-          
+
         default:
             std::cerr << "Invalid option\n\n";
             print_short_help();
@@ -123,26 +122,25 @@ int main(int argc, char **argv)
     if ( (optind + 2) < argc) {
         std::cerr << "More than two input files given\n";
         return EXIT_FAILURE;
-    } else if ( (optind + 2) > argc)
-    {
+    } else if ( (optind + 2) > argc) {
         std::cerr << "Need two input files\n";
         return EXIT_FAILURE;
     } else {
         mutator_file = fopen(argv[(optind)], "r");
         if (mutator_file == NULL) {
             std::cerr << "Could not open file " << argv[(optind)]
-                  << std::endl;
+                      << std::endl;
             return 1;
         }
         lexicon_file = fopen(argv[(optind + 1)], "r");
         if (lexicon_file == NULL) {
             std::cerr << "Could not open file " << argv[(optind + 1)]
-                  << std::endl;
+                      << std::endl;
             return 1;
         }
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
+    hfst_ol::Transducer* mutator;
+    hfst_ol::Transducer* lexicon;
     mutator = new hfst_ol::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
@@ -153,25 +151,25 @@ int main(int argc, char **argv)
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    
-    hfst_ol::Speller * speller;
+
+    hfst_ol::Speller* speller;
 
     try {
         speller = new hfst_ol::Speller(mutator, lexicon);
     } catch (hfst_ol::AlphabetTranslationException& e) {
         std::cerr <<
-        "Unable to build speller - symbol " << e.what() << " not "
-        "present in lexicon's alphabet\n";
+            "Unable to build speller - symbol " << e.what() << " not "
+            "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
     }
-    
-    char * str = (char*) malloc(65535);
+
+    char* str = (char*) malloc(65535);
     while (!std::cin.eof()) {
         std::cin.getline(str, 65535);
         if (str[0] == '\0') {
             continue;
         }
-            // n += 1
+        // n += 1
         char* p = strdup(str);
         char* tok = strtok(p, "\t");
         assert(tok != NULL);
@@ -184,27 +182,22 @@ int main(int argc, char **argv)
         char* context = strdup(tok);
         // unknown += (corr in NWORDS)
         hfst_ol::CorrectionQueue corrections = speller->correct(mispelt);
-        if (corrections.size() == 0)
-          {
+        if (corrections.size() == 0) {
             // correction too far
             fprintf(stdout, "%s\t%s\t%s[inf]\t%s\n",
                     mispelt, corr, mispelt, context);
-          }
-        else
-          {
+        } else {
             fprintf(stdout, "%s\t%s", mispelt, corr);
-            if (speller->check(mispelt))
-              {
+            if (speller->check(mispelt)) {
                 fprintf(stdout, "\t%s[0]", mispelt);
-              }
-            while (corrections.size() > 0)
-              {
+            }
+            while (corrections.size() > 0) {
                 fprintf(stdout, "\t%s[%f]", corrections.top().first.c_str(),
                         corrections.top().second);
                 corrections.pop();
-              }
+            }
             fprintf(stdout, "\t%s\n", context);
-          } // corrections size != 0
-      }
+        } // corrections size != 0
+    }
     return EXIT_SUCCESS;
 }

--- a/main-fsmnlp-2012.cc
+++ b/main-fsmnlp-2012.cc
@@ -1,23 +1,23 @@
 /*
-  
-  Copyright 2009 University of Helsinki
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-  http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  
-*/
+ *
+ * Copyright 2009 University of Helsinki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /*
-  This is a toy commandline utility for testing spellers on standard io.
+ * This is a toy commandline utility for testing spellers on standard io.
  */
 
 
@@ -49,32 +49,32 @@ clock_t profile_start, profile_end;
 bool print_usage(void)
 {
     std::cerr <<
-    "\n" <<
-    "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
-    "       " << PACKAGE_NAME << " [OPTIONS] ZHFST-ARCHIVE\n" <<
-    "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
-    "print corrected output\n" <<
-    "Second form seeks error sources and lexicons from the ZHFST-ARCHIVE\n"
-    "\n" <<
-    "  -h, --help                  Print this help message\n" <<
-    "  -V, --version               Print version information\n" <<
-    "  -v, --verbose               Be verbose\n" <<
-    "  -q, --quiet                 Don't be verbose (default)\n" <<
-    "  -s, --silent                Same as quiet\n" <<
-    "\n" <<
-    "\n" <<
-    "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
-    "\n";
+        "\n" <<
+        "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
+        "       " << PACKAGE_NAME << " [OPTIONS] ZHFST-ARCHIVE\n" <<
+        "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
+        "print corrected output\n" <<
+        "Second form seeks error sources and lexicons from the ZHFST-ARCHIVE\n"
+        "\n" <<
+        "  -h, --help                  Print this help message\n" <<
+        "  -V, --version               Print version information\n" <<
+        "  -v, --verbose               Be verbose\n" <<
+        "  -q, --quiet                 Don't be verbose (default)\n" <<
+        "  -s, --silent                Same as quiet\n" <<
+        "\n" <<
+        "\n" <<
+        "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
+        "\n";
     return true;
 }
 
 bool print_version(void)
 {
     std::cerr <<
-    "\n" <<
-    PACKAGE_STRING << std::endl <<
-    __DATE__ << " " __TIME__ << std::endl <<
-    "copyright (C) 2009 - 2011 University of Helsinki\n";
+        "\n" <<
+        PACKAGE_STRING << std::endl <<
+        __DATE__ << " " __TIME__ << std::endl <<
+        "copyright (C) 2009 - 2011 University of Helsinki\n";
     return true;
 }
 
@@ -90,17 +90,17 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
     FILE* mutator_file = fopen(errmodel_filename, "r");
     if (mutator_file == NULL) {
         std::cerr << "Could not open file " << errmodel_filename
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
     }
     FILE* lexicon_file = fopen(acceptor_filename, "r");
     if (lexicon_file == NULL) {
         std::cerr << "Could not open file " << acceptor_filename
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
+    hfst_ol::Transducer* mutator;
+    hfst_ol::Transducer* lexicon;
     mutator = new hfst_ol::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
@@ -111,36 +111,35 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    
-    hfst_ol::Speller * speller;
+
+    hfst_ol::Speller* speller;
 
     try {
         speller = new hfst_ol::Speller(mutator, lexicon);
     } catch (hfst_ol::AlphabetTranslationException& e) {
         std::cerr <<
-        "Unable to build speller - symbol " << e.what() << " not "
-        "present in lexicon's alphabet\n";
+            "Unable to build speller - symbol " << e.what() << " not "
+            "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
     }
-    char * str = (char*) malloc(2000);
-    
+    char* str = (char*) malloc(2000);
+
     while (!std::cin.eof()) {
         std::cin.getline(str, 2000);
         if (speller->check(str)) {
-        std::cout << "\"" << str << "\" is in the lexicon\n\n";
+            std::cout << "\"" << str << "\" is in the lexicon\n\n";
         } else {
-        hfst_ol::CorrectionQueue corrections = speller->correct(str);
-        if (corrections.size() > 0) {
-            std::cout << "Corrections for \"" << str << "\":\n";
-            while (corrections.size() > 0)
-            {
-            std::cout << corrections.top().first << "    " << corrections.top().second << std::endl;
-            corrections.pop();
+            hfst_ol::CorrectionQueue corrections = speller->correct(str);
+            if (corrections.size() > 0) {
+                std::cout << "Corrections for \"" << str << "\":\n";
+                while (corrections.size() > 0) {
+                    std::cout << corrections.top().first << "    " << corrections.top().second << std::endl;
+                    corrections.pop();
+                }
+                std::cout << std::endl;
+            } else {
+                std::cout << "Unable to correct \"" << str << "\"!\n\n";
             }
-            std::cout << std::endl;
-        } else {
-            std::cout << "Unable to correct \"" << str << "\"!\n\n";
-        }
         }
     }
     return EXIT_SUCCESS;
@@ -149,35 +148,35 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
 
 int
 fallback_spell(const char* errmodel_filename1, const char* errmodel_filename2,
-	     const char* acceptor_filename)
+               const char* acceptor_filename)
 {
     FILE* mutator_file1 = fopen(errmodel_filename1, "r");
     if (mutator_file1 == NULL) {
         std::cerr << "Could not open file " << errmodel_filename1
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
     }
     FILE* mutator_file2 = fopen(errmodel_filename2, "r");
     if (mutator_file2 == NULL) {
         std::cerr << "Could not open file " << errmodel_filename2
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
     }
     FILE* lexicon_file = fopen(acceptor_filename, "r");
     if (lexicon_file == NULL) {
         std::cerr << "Could not open file " << acceptor_filename
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
     }
-    hfst_ol::Transducer * mutator1;
-    hfst_ol::Transducer * mutator2;
-    hfst_ol::Transducer * lexicon;
-    mutator1= new hfst_ol::Transducer(mutator_file1);
+    hfst_ol::Transducer* mutator1;
+    hfst_ol::Transducer* mutator2;
+    hfst_ol::Transducer* lexicon;
+    mutator1 = new hfst_ol::Transducer(mutator_file1);
     if (!mutator1->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    mutator2= new hfst_ol::Transducer(mutator_file2);
+    mutator2 = new hfst_ol::Transducer(mutator_file2);
     if (!mutator2->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
@@ -187,57 +186,55 @@ fallback_spell(const char* errmodel_filename1, const char* errmodel_filename2,
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    
-    hfst_ol::Speller * speller1;
-    hfst_ol::Speller * speller2;
+
+    hfst_ol::Speller* speller1;
+    hfst_ol::Speller* speller2;
 
     try {
         speller1 = new hfst_ol::Speller(mutator1, lexicon);
     } catch (hfst_ol::AlphabetTranslationException& e) {
         std::cerr <<
-        "Unable to build speller - symbol " << e.what() << " not "
-        "present in lexicon's alphabet\n";
+            "Unable to build speller - symbol " << e.what() << " not "
+            "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
     }
     try {
         speller2 = new hfst_ol::Speller(mutator2, lexicon);
     } catch (hfst_ol::AlphabetTranslationException& e) {
         std::cerr <<
-        "Unable to build speller - symbol " << e.what() << " not "
-        "present in lexicon's alphabet\n";
+            "Unable to build speller - symbol " << e.what() << " not "
+            "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
     }
-    char * str = (char*) malloc(2000);
-    
+    char* str = (char*) malloc(2000);
+
     while (!std::cin.eof()) {
         std::cin.getline(str, 2000);
         if (speller1->check(str)) {
-        std::cout << "\"" << str << "\" is in the lexicon 1\n\n";
+            std::cout << "\"" << str << "\" is in the lexicon 1\n\n";
         } else {
-        hfst_ol::CorrectionQueue corrections1 = speller1->correct(str);
-        if (corrections1.size() > 0) {
-            std::cout << "Corrections for \"" << str << "\" w/ source 1:\n";
-            while (corrections1.size() > 0)
-            {
-            std::cout << corrections1.top().first << "    " << corrections1.top().second << std::endl;
-            corrections1.pop();
+            hfst_ol::CorrectionQueue corrections1 = speller1->correct(str);
+            if (corrections1.size() > 0) {
+                std::cout << "Corrections for \"" << str << "\" w/ source 1:\n";
+                while (corrections1.size() > 0) {
+                    std::cout << corrections1.top().first << "    " << corrections1.top().second << std::endl;
+                    corrections1.pop();
+                }
+                std::cout << std::endl;
+            } else {
+                hfst_ol::CorrectionQueue corrections2 = speller2->correct(str);
+                if (corrections2.size() > 0) {
+                    std::cout << "Corrections for \"" << str << "\" w/ source 2:\n";
+                    while (corrections2.size() > 0) {
+                        std::cout << corrections2.top().first << "    " << corrections2.top().second << std::endl;
+                        corrections2.pop();
+                    }
+                    std::cout << std::endl;
+                } else {
+                    std::cout << "Unable to correct \"" << str << "\"!\n\n";
+                }
             }
-            std::cout << std::endl;
-        } else {
-	    hfst_ol::CorrectionQueue corrections2 = speller2->correct(str);
-	    if (corrections2.size() > 0) {
-		std::cout << "Corrections for \"" << str << "\" w/ source 2:\n";
-		while (corrections2.size() > 0)
-		{
-		    std::cout << corrections2.top().first << "    " << corrections2.top().second << std::endl;
-		    corrections2.pop();
-		}
-		std::cout << std::endl;
-	    } else {
-		std::cout << "Unable to correct \"" << str << "\"!\n\n";
-	    }
         }
-	}
     }
     return EXIT_SUCCESS;
 
@@ -246,77 +243,73 @@ fallback_spell(const char* errmodel_filename1, const char* errmodel_filename2,
 int
 zhfst_spell(char* zhfst_filename)
 {
-  ZHfstOspeller speller;
-  try
+    ZHfstOspeller speller;
+    try
     {
-      speller.read_zhfst(zhfst_filename);
+        speller.read_zhfst(zhfst_filename);
     }
-  catch (hfst_ol::ZHfstZipReadingError zhzre)
+    catch (hfst_ol::ZHfstZipReadingError zhzre)
     {
-      std::cerr << "cannot read zhfst archive " << zhfst_filename << ":" 
-          << std::endl
-          << zhzre.what() << "." << std::endl
-          << "trying to read as legacy automata directory" << std::endl;
-      speller.read_legacy(zhfst_filename);
+        std::cerr << "cannot read zhfst archive " << zhfst_filename << ":"
+                  << std::endl
+                  << zhzre.what() << "." << std::endl
+                  << "trying to read as legacy automata directory" << std::endl;
+        speller.read_legacy(zhfst_filename);
     }
-  catch (hfst_ol::ZHfstLegacyReadingError zhlre)
+    catch (hfst_ol::ZHfstLegacyReadingError zhlre)
     {
-      std::cerr << "cannot read legacy hfst speller dir " << zhfst_filename 
-          << ":" << std::endl
-          << zhlre.what() << "." << std::endl;
-      return EXIT_FAILURE;
+        std::cerr << "cannot read legacy hfst speller dir " << zhfst_filename
+                  << ":" << std::endl
+                  << zhlre.what() << "." << std::endl;
+        return EXIT_FAILURE;
     }
 
-  if (verbose)
-    {
-      std::cout << "Following metadata was read from ZHFST archive:" << std::endl
-                << speller.metadata_dump() << std::endl;
+    if (verbose) {
+        std::cout << "Following metadata was read from ZHFST archive:" << std::endl
+                  << speller.metadata_dump() << std::endl;
     }
-  char * str = (char*) malloc(2000);
-    
+    char* str = (char*) malloc(2000);
+
     while (!std::cin.eof()) {
         std::cin.getline(str, 2000);
         if (str[0] == '\0') {
-        break;
+            break;
         }
         if (speller.spell(str)) {
-        std::cout << "\"" << str << "\" is in the lexicon\n\n";
+            std::cout << "\"" << str << "\" is in the lexicon\n\n";
         } else {
-        hfst_ol::CorrectionQueue corrections = speller.suggest(str);
-        if (corrections.size() > 0) {
-            std::cout << "Corrections for \"" << str << "\":\n";
-            while (corrections.size() > 0)
-            {
-            std::cout << corrections.top().first << "    " << corrections.top().second << std::endl;
-            corrections.pop();
+            hfst_ol::CorrectionQueue corrections = speller.suggest(str);
+            if (corrections.size() > 0) {
+                std::cout << "Corrections for \"" << str << "\":\n";
+                while (corrections.size() > 0) {
+                    std::cout << corrections.top().first << "    " << corrections.top().second << std::endl;
+                    corrections.pop();
+                }
+                std::cout << std::endl;
+            } else {
+                std::cout << "Unable to correct \"" << str << "\"!\n\n";
             }
-            std::cout << std::endl;
-        } else {
-            std::cout << "Unable to correct \"" << str << "\"!\n\n";
-        }
         }
     }
     return EXIT_SUCCESS;
-  return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }
 
 void
 hfst_print_profile_line()
-  {
-    if (profile_file == 0)
-      {
+{
+    if (profile_file == 0) {
         return;
-      }
+    }
     fprintf(profile_file, "ospell");
     clock_t profile_end = clock();
-    fprintf(profile_file, "\t%f", ((float)(profile_end - profile_start))
-                                               / CLOCKS_PER_SEC);
+    fprintf(profile_file, "\t%f", ((float) (profile_end - profile_start))
+            / CLOCKS_PER_SEC);
     struct rusage* usage = static_cast<struct rusage*>
-        (malloc(sizeof(struct rusage)));
+                           (malloc(sizeof(struct rusage)));
     errno = 0;
     int rv = getrusage(RUSAGE_SELF, usage);
-    if (rv != -1)
-      {
+    if (rv != -1) {
         fprintf(profile_file, "\t%lu.%lu\t%lu.%lu"
                 "\t%ld\t%ld\t%ld"
                 "\t%ld"
@@ -330,38 +323,36 @@ hfst_print_profile_line()
                 usage->ru_maxrss, usage->ru_ixrss, usage->ru_idrss,
                 usage->ru_isrss,
                 usage->ru_minflt, usage->ru_majflt, usage->ru_nswap,
-                usage->ru_inblock, usage->ru_oublock, 
+                usage->ru_inblock, usage->ru_oublock,
                 usage->ru_msgsnd, usage->ru_msgrcv,
                 usage->ru_nsignals,
                 usage->ru_nvcsw, usage->ru_nivcsw);
-      }
-    else
-      {
+    } else {
         fprintf(profile_file, "\tgetrusage: %s", strerror(errno));
-      }
+    }
     fprintf(profile_file, "\n");
-  }
+}
 
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-    
+
     int c;
-  
+
 #if HAVE_GETOPT_H
     while (true) {
         static struct option long_options[] =
-            {
+        {
             // first the hfst-mandated options
-            {"help",         no_argument,       0, 'h'},
-            {"version",      no_argument,       0, 'V'},
-            {"verbose",      no_argument,       0, 'v'},
-            {"quiet",        no_argument,       0, 'q'},
-            {"silent",       no_argument,       0, 's'},
-            {"profile",      required_argument, 0, 'p'},
-            {0,              0,                 0,  0 }
-            };
-          
+            { "help",         no_argument,       0, 'h' },
+            { "version",      no_argument,       0, 'V' },
+            { "verbose",      no_argument,       0, 'v' },
+            { "quiet",        no_argument,       0, 'q' },
+            { "silent",       no_argument,       0, 's' },
+            { "profile",      required_argument, 0, 'p' },
+            { 0,              0,                 0,  0 }
+        };
+
         int option_index = 0;
         c = getopt_long(argc, argv, "hVvqsp:", long_options, &option_index);
 
@@ -373,23 +364,22 @@ int main(int argc, char **argv)
             print_usage();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'V':
             print_version();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'v':
             verbose = true;
             quiet = false;
             break;
-          
+
         case 'p':
             profile_file = fopen(optarg, "a");
-            if (NULL == profile_file)
-              {
+            if (NULL == profile_file) {
                 perror("Couldn't open profiling file for appending");
-              }
+            }
             profile_start = clock();
             break;
         case 'q': // fallthrough
@@ -397,7 +387,7 @@ int main(int argc, char **argv)
             quiet = true;
             verbose = false;
             break;
-          
+
         default:
             std::cerr << "Invalid option\n\n";
             print_short_help();
@@ -407,34 +397,25 @@ int main(int argc, char **argv)
     }
 #else
     int optind = 1;
-#endif
-    // no more options, we should now be at the input filenames
+#endif // if HAVE_GETOPT_H
+       // no more options, we should now be at the input filenames
     int rv = EXIT_SUCCESS;
-    if (optind == (argc - 3))
-      {
-	  rv = fallback_spell(argv[optind], argv[optind+1], argv[optind+2]);
-      }
-    else if (optind == (argc - 2))
-      {
-        rv = legacy_spell(argv[optind], argv[optind+1]);
-      }
-    else if (optind == (argc - 1))
-      {
+    if (optind == (argc - 3)) {
+        rv = fallback_spell(argv[optind], argv[optind + 1], argv[optind + 2]);
+    } else if (optind == (argc - 2)) {
+        rv = legacy_spell(argv[optind], argv[optind + 1]);
+    } else if (optind == (argc - 1)) {
         rv = zhfst_spell(argv[optind]);
-      }
-    else if (optind < (argc - 3))
-      {
+    } else if (optind < (argc - 3)) {
         std::cerr << "No more than three free parameters allowed" << std::endl;
         print_short_help();
         return EXIT_FAILURE;
-      }
-    else if (optind >= argc)
-      {
+    } else if (optind >= argc) {
         std::cerr << "Give full path to zhfst spellers or two automata"
-            << std::endl;
+                  << std::endl;
         print_short_help();
         return EXIT_FAILURE;
-      }
+    }
     hfst_print_profile_line();
     return rv;
-  }
+}

--- a/main-ispell.cc
+++ b/main-ispell.cc
@@ -1,23 +1,23 @@
 /*
-  
-  Copyright 2009 University of Helsinki
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-  http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  
-*/
+ *
+ * Copyright 2009 University of Helsinki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /*
-  This is a toy commandline utility for testing spellers on standard io.
+ * This is a toy commandline utility for testing spellers on standard io.
  */
 
 
@@ -30,8 +30,8 @@
 #if HAVE_ERROR_H
 #  include <error.h>
 #else
-#  define error(status, errnum, fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__); \
-  if (status != 0) exit(status);
+#  define error(status, errnum, fmt, ...) fprintf(stderr, fmt, ## __VA_ARGS__); \
+    if (status != 0) exit(status);
 #endif
 
 #include "ol-exceptions.h"
@@ -46,64 +46,57 @@ static bool verbose = false;
 
 char*
 find_dicts(const char* langcode)
-  {
+{
     FILE* testhandle = NULL;
-    char* testname = (char*)malloc(sizeof(char) * 
-                            (strlen(langcode) + strlen("speller-.zhfst") + 1));
+    char* testname = (char*) malloc(sizeof(char) *
+                                    (strlen(langcode) + strlen("speller-.zhfst") + 1));
     int rv = sprintf(testname, "speller-%s.zhfst", langcode);
-    if (rv == 0)
-      {
+    if (rv == 0) {
         perror("sprinting path");
-      }
+    }
     testhandle = fopen(testname, "r");
-    if (testhandle != NULL)
-      {
+    if (testhandle != NULL) {
         fclose(testhandle);
         return testname;
-      }
+    }
     free(testname);
-    testname = (char*)malloc(sizeof(char) * 
-                            (strlen(langcode) + 
-                             strlen("/usr/share/voikko/3/speller-.zhfst") + 1));
+    testname = (char*) malloc(sizeof(char) *
+                              (strlen(langcode) +
+                               strlen("/usr/share/voikko/3/speller-.zhfst") + 1));
     rv = sprintf(testname, "/usr/share/voikko/3/speller-%s.zhfst",
-                     langcode);
-    if (rv == 0)
-      {
+                 langcode);
+    if (rv == 0) {
         perror("sprinting path");
-      }
+    }
     testhandle = fopen(testname, "r");
-    if (testhandle != NULL)
-      {
+    if (testhandle != NULL) {
         fclose(testhandle);
         return testname;
-      }
+    }
     free(testname);
     char* homepath = getenv("HOME");
-    if (homepath == NULL)
-      {
+    if (homepath == NULL) {
         return NULL;
-      }
-    testname = (char*)malloc(sizeof(char) * 
-                      (strlen(homepath) + strlen("/.voikko/3/speller-.zhfst") +
-                       strlen(langcode) + 1));
+    }
+    testname = (char*) malloc(sizeof(char) *
+                              (strlen(homepath) + strlen("/.voikko/3/speller-.zhfst") +
+                               strlen(langcode) + 1));
     rv = sprintf(testname, "%s/.voikko/3/speller-%s.zhfst", homepath,
-                     langcode);
-    if (rv == 0)
-      {
+                 langcode);
+    if (rv == 0) {
         perror("sprinting path");
-      }
+    }
     testhandle = fopen(testname, "r");
-    if (testhandle != NULL)
-      {
+    if (testhandle != NULL) {
         fclose(testhandle);
         return testname;
-      }
+    }
     free(testname);
     return NULL;
-  }
+}
 
 bool print_usage(void)
-  {
+{
     fprintf(stdout, "Usage: %s [OPTION]... [FILE]...\n"
             "Check spelling of each FILE. Without FILE, check standard input."
             "\n\n", "hfst-ispell");
@@ -124,222 +117,194 @@ bool print_usage(void)
             "from one word/line input\n"
             "\n");
     fprintf(stdout, "Examples: %s -d fi file.txt\n"
-                    "          %s -l file.txt\n\n", "hfst-ispell", "hfst-ispell");
+            "          %s -l file.txt\n\n", "hfst-ispell", "hfst-ispell");
     fprintf(stdout, "Report bugs to " PACKAGE_BUGREPORT "\n");
     return true;
-  }
+}
 
 bool print_version(bool ispell_strict)
-  {
+{
     fprintf(stdout, "@(#) International Ispell Version 3.2.06 (but really "
             PACKAGE_STRING ")\n\n");
-    if (!ispell_strict)
-      {
+    if (!ispell_strict) {
         fprintf(stdout, "Copyright (C) 2013 University of Helsinki. APL\n");
         fprintf(stdout,
-            "This is free software; see the source for copying conditions. "
-           " There is NO\n"
-           "warranty; not even for MERCHANTABILITY or FITNESS FOR A "
-          " PARTICULAR PURPOSE,\n"
-          "to the extent permitted by law.\n");
-      }
+                "This is free software; see the source for copying conditions. "
+                " There is NO\n"
+                "warranty; not even for MERCHANTABILITY or FITNESS FOR A "
+                " PARTICULAR PURPOSE,\n"
+                "to the extent permitted by law.\n");
+    }
     return true;
-  }
+}
 
 bool print_short_help(void)
-  {
+{
     print_usage();
     return true;
-  }
+}
 
 static
 void
 print_correct(const char* /*s*/)
-  {
+{
     fprintf(stdout, "*\n");
-  }
+}
 
 static
 void
 print_corrections(const char* s, hfst_ol::CorrectionQueue& c)
-  {
+{
     fprintf(stdout, "& %s %zu %d: ", s, c.size(), 0);
     bool comma = false;
-    while (c.size() > 0)
-      {
-        if (comma)
-          {
+    while (c.size() > 0) {
+        if (comma) {
             fprintf(stdout, ", ");
-          }
+        }
         fprintf(stdout, "%s", c.top().first.c_str());
         comma = true;
         c.pop();
-      }
+    }
     fprintf(stdout, "\n");
-  }
+}
 
 static
 void
 print_no_corrects(const char* s)
-  {
+{
     fprintf(stdout, "# %s %d\n", s, 0);
-  }
+}
 
 int
 legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
-  {
+{
     FILE* mutator_file = fopen(errmodel_filename, "r");
-    if (mutator_file == NULL) 
-      {
+    if (mutator_file == NULL) {
         std::cerr << "Could not open file " << errmodel_filename
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
-      }
+    }
     FILE* lexicon_file = fopen(acceptor_filename, "r");
-    if (lexicon_file == NULL) 
-      {
+    if (lexicon_file == NULL) {
         std::cerr << "Could not open file " << acceptor_filename
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
-      }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
+    }
+    hfst_ol::Transducer* mutator;
+    hfst_ol::Transducer* lexicon;
     mutator = new hfst_ol::Transducer(mutator_file);
-    if (!mutator->is_weighted()) 
-      {
+    if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
-      }
+    }
     lexicon = new hfst_ol::Transducer(lexicon_file);
-    if (!lexicon->is_weighted()) 
-      {
+    if (!lexicon->is_weighted()) {
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
-      }
-    hfst_ol::Speller * speller;
-    try 
-      {
+    }
+    hfst_ol::Speller* speller;
+    try
+    {
         speller = new hfst_ol::Speller(mutator, lexicon);
-      }
-    catch (hfst_ol::AlphabetTranslationException& e) 
-      {
+    }
+    catch (hfst_ol::AlphabetTranslationException& e)
+    {
         std::cerr <<
-        "Unable to build speller - symbol " << e.what() << " not "
-        "present in lexicon's alphabet\n";
+            "Unable to build speller - symbol " << e.what() << " not "
+            "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
-      }
-    char * str = (char*) malloc(2000);
-    while (!std::cin.eof()) 
-      {
+    }
+    char* str = (char*) malloc(2000);
+    while (!std::cin.eof()) {
         std::cin.getline(str, 2000);
-        if (str[0] == '\0') 
-          {
+        if (str[0] == '\0') {
             fprintf(stdout, "\n");
             continue;
-          }
-        if (str[strlen(str) - 1] == '\r')
-          {
+        }
+        if (str[strlen(str) - 1] == '\r') {
             fprintf(stderr, "\\r is not allowed\n");
             exit(1);
-          }
-        if (speller->check(str)) 
-          {
+        }
+        if (speller->check(str)) {
             print_correct(str);
-          }
-        else
-          {
+        } else {
             hfst_ol::CorrectionQueue corrections = speller->correct(str, 5);
-            if (corrections.size() > 0) 
-              {
+            if (corrections.size() > 0) {
                 print_corrections(str, corrections);
-              }
-            else
-              {
+            } else {
                 print_no_corrects(str);
-              }
-          }
-      }
+            }
+        }
+    }
     return EXIT_SUCCESS;
-  }
+}
 
 int
 zhfst_spell(char* zhfst_filename, FILE* input)
-  {
+{
     ZHfstOspeller speller;
     try
-      {
+    {
         speller.read_zhfst(zhfst_filename);
-      }
+    }
     catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
-      {
+    {
         std::cerr << "cannot finish reading zhfst archive " << zhfst_filename <<
-                   ":" << zhmdpe.what() << "." << std::endl;
+            ":" << zhmdpe.what() << "." << std::endl;
         return EXIT_FAILURE;
-      }
+    }
     catch (hfst_ol::ZHfstZipReadingError zhzre)
-      {
-        std::cerr << "cannot read zhfst archive " << zhfst_filename << ":" 
-          << zhzre.what() << "." << std::endl
-          << "trying to read as legacy automata directory" << std::endl;
-        try 
-          {
+    {
+        std::cerr << "cannot read zhfst archive " << zhfst_filename << ":"
+                  << zhzre.what() << "." << std::endl
+                  << "trying to read as legacy automata directory" << std::endl;
+        try
+        {
             speller.read_legacy(zhfst_filename);
-          }
+        }
         catch (hfst_ol::ZHfstLegacyReadingError zhlre)
-          {
-            std::cerr << "cannot fallback to read legacy hfst speller dir " 
-              << zhfst_filename 
-              << ":" << std::endl
-              << zhlre.what() << "." << std::endl;
+        {
+            std::cerr << "cannot fallback to read legacy hfst speller dir "
+                      << zhfst_filename
+                      << ":" << std::endl
+                      << zhlre.what() << "." << std::endl;
             return EXIT_FAILURE;
-          }
-      }
-    if (verbose)
-      {
+        }
+    }
+    if (verbose) {
         std::cout << "Following metadata was read from ZHFST archive:" << std::endl
-                << speller.metadata_dump() << std::endl;
-      }
+                  << speller.metadata_dump() << std::endl;
+    }
     char* str = NULL;
     size_t len = 0;
-    while (getline(&str, &len, input) != -1) 
-      {
-        if (str[0] == '\0') 
-          {
+    while (getline(&str, &len, input) != -1) {
+        if (str[0] == '\0') {
             break;
-          }
-        if (str[strlen(str) - 1] == '\r')
-          {
+        }
+        if (str[strlen(str) - 1] == '\r') {
             fprintf(stderr, "\\r is not allowed\n");
             exit(1);
-          }
-        else if (str[strlen(str) - 1] == '\n')
-          {
+        } else if (str[strlen(str) - 1] == '\n') {
             str[strlen(str) - 1] = '\0';
-          }
-        if (speller.spell(str)) 
-          {
+        }
+        if (speller.spell(str)) {
             print_correct(str);
-          } 
-        else 
-          {
+        } else {
             hfst_ol::CorrectionQueue corrections = speller.suggest(str);
-            if (corrections.size() > 0)
-              {
+            if (corrections.size() > 0) {
                 print_corrections(str, corrections);
-              }
-            else
-              {
+            } else {
                 print_no_corrects(str);
-              }
-          }
-      }
+            }
+        }
+    }
     free(str);
     return EXIT_SUCCESS;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-    
+
     int c;
     char* langcode = 0;
     //std::locale::global(std::locale(""));
@@ -347,29 +312,28 @@ int main(int argc, char **argv)
 #if HAVE_GETOPT_H
     while (true) {
         static struct option long_options[] =
-            {
+        {
             // first the hfst-mandated options
-            {"help",         no_argument,       0, 'h'},
-            {"version",      no_argument,       0, 'v'},
-            {"one",          no_argument,       0, '1'},
-            {"ispell",       no_argument,       0, 'a'},
-            {"check-url",    no_argument,       0, 'X'},
-            {"dictionary",   required_argument, 0, 'd'},
-            {"list",         no_argument,       0, 'D'},
-            {"mispelt",      no_argument,       0, 'l'},
-            {"misslines",    no_argument,       0, 'L'},
-            {"wordperline",  no_argument,       0, 'w'},
-            {0,              0,                 0,  0 }
-            };
-          
+            { "help",         no_argument,       0, 'h' },
+            { "version",      no_argument,       0, 'v' },
+            { "one",          no_argument,       0, '1' },
+            { "ispell",       no_argument,       0, 'a' },
+            { "check-url",    no_argument,       0, 'X' },
+            { "dictionary",   required_argument, 0, 'd' },
+            { "list",         no_argument,       0, 'D' },
+            { "mispelt",      no_argument,       0, 'l' },
+            { "misslines",    no_argument,       0, 'L' },
+            { "wordperline",  no_argument,       0, 'w' },
+            { 0,              0,                 0,  0 }
+        };
+
         int option_index = 0;
         c = getopt_long(argc, argv, "1ad:DGhvlLw", long_options, &option_index);
 
         if (c == -1) // no more options to look at
             break;
 
-        switch (c) 
-          {
+        switch (c) {
         case 'h':
             print_usage();
             return EXIT_SUCCESS;
@@ -390,66 +354,52 @@ int main(int argc, char **argv)
             break;
         }
     }
-    if (version == 1) 
-      {
+    if (version == 1) {
         print_version(false);
         return EXIT_SUCCESS;
-      }
-    else if (version == 2)
-      {
+    } else if (version == 2) {
         print_version(true);
         return EXIT_SUCCESS;
-      }
-    else if (version >= 3)
-      {
+    } else if (version >= 3) {
         fprintf(stdout, "Come on, really?\n");
         exit(version);
-      }
+    }
 #else
     int optind = 1;
-#endif
-    // find the dicts
+#endif // if HAVE_GETOPT_H
+       // find the dicts
     char* zhfst_file = 0;
-    if (NULL == langcode)
-      {
+    if (NULL == langcode) {
         fprintf(stderr, "Currently -d is required since I'm too lazy to check "
                 "locale\n");
         exit(1);
-      }
-    else
-      {
+    } else {
         zhfst_file = find_dicts(langcode);
-        if (NULL == zhfst_file)
-          {
+        if (NULL == zhfst_file) {
             fprintf(stderr, "Could not find dictionary %s in standard "
                     "locations\n"
                     "Please install one of:\n"
                     "  /usr/share/voikko/3/speller-%s.zhfst\n"
                     "  $HOME/.voikko/3/speller-%s.zhfst\n"
-                    "  ./speller-%s.zhfst\n", 
+                    "  ./speller-%s.zhfst\n",
                     langcode, langcode, langcode, langcode);
             exit(1);
-          }
-      }
+        }
+    }
     // no more options, we should now be at the input filenames
-    if (optind == argc)
-      {
+    if (optind == argc) {
         return zhfst_spell(zhfst_file, stdin);
-      }
-    else if (optind < argc)
-      {
-        while (optind < argc)
-          {
+    } else if (optind < argc) {
+        while (optind < argc) {
             FILE* infile = fopen(argv[optind], "r");
-            if (NULL == infile)
-              {
+            if (NULL == infile) {
                 fprintf(stderr, "Could not open %s for reading",
                         argv[optind]);
                 exit(1);
-              }
+            }
             zhfst_spell(zhfst_file, infile);
             optind++;
-          }
-      }
+        }
+    }
     return EXIT_SUCCESS;
-  }
+}

--- a/main-lrec2013.cc
+++ b/main-lrec2013.cc
@@ -1,23 +1,23 @@
 /*
-  
-  Copyright 2009 University of Helsinki
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-  http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  
-*/
+ *
+ * Copyright 2009 University of Helsinki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /*
-  This is a toy commandline utility for testing spellers on standard io.
+ * This is a toy commandline utility for testing spellers on standard io.
  */
 
 
@@ -30,8 +30,8 @@
 #if HAVE_ERROR_H
 #  include <error.h>
 #else
-#define error(status, errnum, format, ...) fprintf(stderr, format, ##__VA_ARGS__); \
-  if (status != 0) exit(status);
+#define error(status, errnum, format, ...) fprintf(stderr, format, ## __VA_ARGS__); \
+    if (status != 0) exit(status);
 #endif
 #include <time.h>
 #include <sys/time.h>
@@ -72,25 +72,25 @@ bool
 print_usage(void)
 {
     std::cerr <<
-    "\n" <<
-    "Usage: " << PACKAGE_NAME << " [OPTIONS] ZHFST\n" <<
-    "Run a composition of ZHFST and field 1 of standard input and\n" <<
-    "print corrected output on fields 3...\n" <<
-    "\n" <<
-    "  -h, --help                  Print this help message\n" <<
-    "  -V, --version               Print version information\n" <<
-    "  -v, --verbose               Be verbose\n" <<
-    "  -q, --quiet                 Don't be verbose (default)\n" <<
-    "  -s, --silent                Same as quiet\n" <<
-    "  -P, --profile=PFILE         Save profiling data to PFILE\n" <<
-    "  -X, --statistics=SFILE      Save statistsics to SFILE\n" <<
-    "  -H, --histogram=HFILE       Save match numbes to HFILE\n" <<
-    "  -n, --n-best=NBEST          Collect and provide only NBEST suggestions\n"
-    <<
-    "\n" <<
-    "\n" <<
-    "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
-    "\n";
+        "\n" <<
+        "Usage: " << PACKAGE_NAME << " [OPTIONS] ZHFST\n" <<
+        "Run a composition of ZHFST and field 1 of standard input and\n" <<
+        "print corrected output on fields 3...\n" <<
+        "\n" <<
+        "  -h, --help                  Print this help message\n" <<
+        "  -V, --version               Print version information\n" <<
+        "  -v, --verbose               Be verbose\n" <<
+        "  -q, --quiet                 Don't be verbose (default)\n" <<
+        "  -s, --silent                Same as quiet\n" <<
+        "  -P, --profile=PFILE         Save profiling data to PFILE\n" <<
+        "  -X, --statistics=SFILE      Save statistsics to SFILE\n" <<
+        "  -H, --histogram=HFILE       Save match numbes to HFILE\n" <<
+        "  -n, --n-best=NBEST          Collect and provide only NBEST suggestions\n"
+              <<
+        "\n" <<
+        "\n" <<
+        "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
+        "\n";
     return true;
 }
 
@@ -110,209 +110,168 @@ bool print_short_help(void)
 
 int
 zhfst_spell(char* zhfst_filename)
-  {
+{
     ZHfstOspeller speller;
-    try 
-      {
+    try
+    {
         speller.read_zhfst(zhfst_filename);
-      }
-   catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
-     {
-       error(EXIT_FAILURE, 0, "error while parsing metadata in %s: %s\n",
-             zhfst_filename, zhmdpe.what());
-     }
-   catch (hfst_ol::ZHfstZipReadingError zhzre)
-     {
-       error(EXIT_FAILURE, 0, "error while unzipping %s: %s\n",
-             zhfst_filename, zhzre.what());
-     }
-    if (verbose)
-      {
+    }
+    catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
+    {
+        error(EXIT_FAILURE, 0, "error while parsing metadata in %s: %s\n",
+              zhfst_filename, zhmdpe.what());
+    }
+    catch (hfst_ol::ZHfstZipReadingError zhzre)
+    {
+        error(EXIT_FAILURE, 0, "error while unzipping %s: %s\n",
+              zhfst_filename, zhzre.what());
+    }
+    if (verbose) {
         fprintf(stdout, "Following metadata was read from ZHFST archive:\n%s",
                 speller.metadata_dump().c_str());
-      }
-    char * str = (char*) malloc(2000);
-    char* always_incorrect = strdup("\001\002@ALWAYS INCORRECT@"); 
+    }
+    char* str = (char*) malloc(2000);
+    char* always_incorrect = strdup("\001\002@ALWAYS INCORRECT@");
     bool correcting = false;
     unsigned long linen = 0;
-    if (verbose)
-      {
+    if (verbose) {
         fprintf(stdout, "Reading corrections from <stdin>\n");
-      }
-    else
-      {
-        fprintf(stdout, 
+    } else {
+        fprintf(stdout,
                 "Misspelled\tCorrect\tSuggestion 1\tSuggestion 2\t...\n");
-      }
+    }
     while (!std::cin.eof()) {
         linen++;
         std::cin.getline(str, 2000);
-        if (str[0] == '\0') 
-          {
+        if (str[0] == '\0') {
             fprintf(stderr, "Skipping empty line at %lu\n", linen);
             continue;
-          }
-        if (str[strlen(str) - 1] == '\r')
-          {
+        }
+        if (str[strlen(str) - 1] == '\r') {
             fprintf(stdout, "There is a WINDOWS linebreak in this file\n"
-                "Please convert with dos2unix or fromdos");
+                    "Please convert with dos2unix or fromdos");
             exit(3);
-          }
+        }
         char* tab = strchr(str, '\t');
         char* correct = 0;
-        if (tab != NULL)
-          {
+        if (tab != NULL) {
             *tab = '\0';
             correct = strdup(tab + 1);
             char* p = correct;
-            while (*p != '\0')
-              {
+            while (*p != '\0') {
                 p++;
-                if ((*p == '\n') || (*p == '\t'))
-                  {
+                if ((*p == '\n') || (*p == '\t')) {
                     *p = '\0';
-                  }
-              }
+                }
+            }
             correcting = true;
-          }
-        else
-          {
+        } else {
             correct = always_incorrect;
             correcting = false;
-          }
-        if (verbose)
-          {
+        }
+        if (verbose) {
             fprintf(stdout, "Checking if %s == %s\n", str, correct);
-          }
-        else
-          {
+        } else {
             fprintf(stdout, "%s\t%s", str, correct);
-          }
+        }
         lines++;
         int i = 0;
         bool any_corrects = false;
-        if (speller.spell(str)) 
-          {
+        if (speller.spell(str)) {
             // spelling correct string is as if one suggestion was
             // made at edit 0 for means of this article;
             i++;
-            if (strcmp(str, correct) == 0)
-              {
+            if (strcmp(str, correct) == 0) {
                 corrects_at[i]++;
                 any_corrects = true;
-              }
+            }
             results[i]++;
             in_language++;
-            if (verbose)
-              {
+            if (verbose) {
                 fprintf(stdout, "%s was in the lexicon\n", str);
-              }
-            else
-              {
+            } else {
                 fprintf(stdout, "\t%s", str);
-              }
-          }
+            }
+        }
         hfst_ol::CorrectionQueue corrections = speller.suggest(str /*,
-                                                                max_results */);
-        while (corrections.size() > 0)
-          {
+                                                                    * max_results */);
+        while (corrections.size() > 0) {
             i++;
-            if (i >= check_results)
-              {
+            if (i >= check_results) {
                 break;
-              }
-            if (verbose)
-              {
-                fprintf(stdout, "Trying %s\n", 
+            }
+            if (verbose) {
+                fprintf(stdout, "Trying %s\n",
                         corrections.top().first.c_str());
-              }
-            else
-              {
+            } else {
                 fprintf(stdout, "\t%s",
-                    corrections.top().first.c_str());
-              }
-            if (strcmp(corrections.top().first.c_str(), correct) == 0)
-              {
-                if (i >= max_results)
-                  {
-                    if (verbose)
-                      {
+                        corrections.top().first.c_str());
+            }
+            if (strcmp(corrections.top().first.c_str(), correct) == 0) {
+                if (i >= max_results) {
+                    if (verbose) {
                         fprintf(stdout, "%d was correct beyond threshold\n", i);
-                      }
+                    }
                     corrects_beyond++;
-                  }
-                else
-                  {
-                    if (verbose)
-                      {
+                } else {
+                    if (verbose) {
                         fprintf(stdout, "%d was correct\n", i);
-                      }
+                    }
                     corrects_at[i]++;
-                  }
+                }
                 any_corrects = true;
-              }
+            }
             corrections.pop();
-          } // while corrections
-        if (!any_corrects)
-          {
+        } // while corrections
+        if (!any_corrects) {
             no_corrects++;
-            if (verbose)
-              {
+            if (verbose) {
                 fprintf(stdout, "no corrects for %s ?= %s\n", str, correct);
-              }
-          }
+            }
+        }
         fprintf(stdout, "\n");
-        if (i >= max_results)
-          {
+        if (i >= max_results) {
             results_beyond++;
-          }
-        else
-          {
+        } else {
             results[i]++;
-          }
-        if (!speller.spell(correct))
-          {
-            if (verbose)
-              {
+        }
+        if (!speller.spell(correct)) {
+            if (verbose) {
                 fprintf(stdout, "could not have been corrected, missing %s\n",
                         correct);
-              }
+            }
             correct_not_in_lm++;
-          }
-        if (correcting)
-          {
+        }
+        if (correcting) {
             free(correct);
-          }
-      } 
+        }
+    }
     return EXIT_SUCCESS;
 
 }
 
 void
 hfst_print_profile_line()
-  {
-    if (profile_file == 0)
-      {
+{
+    if (profile_file == 0) {
         return;
-      }
-    if (ftell(profile_file) == 0L)
-      {
+    }
+    if (ftell(profile_file) == 0L) {
         fprintf(profile_file, "name\tclock\t"
                 "utime\tstime\tmaxrss\tixrss\tidrss\tisrss\t"
                 "minflt\tmajflt\tnswap\tinblock\toublock\t"
                 "msgsnd\tmsgrcv\tnsignals\tnvcsw\tnivcsw\n");
-      }
+    }
 
     fprintf(profile_file, "ospell");
     profile_end = clock();
-    fprintf(profile_file, "\t%f", ((float)(profile_end - profile_start))
-                                               / CLOCKS_PER_SEC);
+    fprintf(profile_file, "\t%f", ((float) (profile_end - profile_start))
+            / CLOCKS_PER_SEC);
     struct rusage* usage = static_cast<struct rusage*>
-        (malloc(sizeof(struct rusage)));
+                           (malloc(sizeof(struct rusage)));
     errno = 0;
     int rv = getrusage(RUSAGE_SELF, usage);
-    if (rv != -1)
-      {
+    if (rv != -1) {
         fprintf(profile_file, "\t%lu.%lu\t%lu.%lu"
                 "\t%ld\t%ld\t%ld"
                 "\t%ld"
@@ -326,41 +285,35 @@ hfst_print_profile_line()
                 usage->ru_maxrss, usage->ru_ixrss, usage->ru_idrss,
                 usage->ru_isrss,
                 usage->ru_minflt, usage->ru_majflt, usage->ru_nswap,
-                usage->ru_inblock, usage->ru_oublock, 
+                usage->ru_inblock, usage->ru_oublock,
                 usage->ru_msgsnd, usage->ru_msgrcv,
                 usage->ru_nsignals,
                 usage->ru_nvcsw, usage->ru_nivcsw);
-      }
-    else
-      {
+    } else {
         fprintf(profile_file, "\tgetrusage: %s", strerror(errno));
-      }
+    }
     fprintf(profile_file, "\n");
-  }
+}
 
 void
 print_statistics()
-  {
-    if (NULL == statistics_file)
-      {
+{
+    if (NULL == statistics_file) {
         return;
-      }
-    if (lines == 0)
-      {
+    }
+    if (lines == 0) {
         fprintf(stderr, "DATOISSA VIRHE. END.\n");
         exit(1);
-      }
+    }
     // calculate stuff
     unsigned long corrects_rest = 0;
     unsigned long total_results = 0;
-    for (int i = 6; i < max_results; i++)
-      {
+    for (int i = 6; i < max_results; i++) {
         corrects_rest += corrects_at[i];
-      }
-    for (int i = 0; i < max_results; i++)
-      {
+    }
+    for (int i = 0; i < max_results; i++) {
         total_results += results[i] * i;
-      }
+    }
     some_results = lines - results[0];
     fixable_lines = lines - correct_not_in_lm;
     // print
@@ -392,42 +345,40 @@ print_statistics()
             static_cast<float>(corrects_at[5]) / static_cast<float>(fixable_lines) * 100.0f,
             static_cast<float>(corrects_rest) / static_cast<float>(fixable_lines) * 100.0f,
             static_cast<float>(no_corrects - correct_not_in_lm) / static_cast<float>(fixable_lines) * 100.0f);
-    if (histogram_file == NULL)
-      {
+    if (histogram_file == NULL) {
         return;
-      }
+    }
     fprintf(histogram_file, "Result count\tfrequency\n");
-    for (int i = 0; i < max_results; i++)
-      {
+    for (int i = 0; i < max_results; i++) {
         fprintf(histogram_file, "%u\t%lu\n", i, results[i]);
-      }
-  }
+    }
+}
 
-int main(int argc, char **argv)
-  {
+int main(int argc, char** argv)
+{
     results = new long[max_results];
     corrects_at = new long[max_results];
-    
+
     int c;
     //std::locale::global(std::locale(""));
-  
+
 #if HAVE_GETOPT_H
     while (true) {
         static struct option long_options[] =
-            {
+        {
             // first the hfst-mandated options
-            {"help",         no_argument,       0, 'h'},
-            {"version",      no_argument,       0, 'V'},
-            {"verbose",      no_argument,       0, 'v'},
-            {"quiet",        no_argument,       0, 'q'},
-            {"silent",       no_argument,       0, 's'},
-            {"profile",      required_argument, 0, 'P'},
-            {"statistics",   required_argument, 0, 'X'},
-            {"histogram",    required_argument, 0, 'H'},
-            {"n-best",       required_argument, 0, 'n'},
-            {0,              0,                 0,  0 }
-            };
-          
+            { "help",         no_argument,       0, 'h' },
+            { "version",      no_argument,       0, 'V' },
+            { "verbose",      no_argument,       0, 'v' },
+            { "quiet",        no_argument,       0, 'q' },
+            { "silent",       no_argument,       0, 's' },
+            { "profile",      required_argument, 0, 'P' },
+            { "statistics",   required_argument, 0, 'X' },
+            { "histogram",    required_argument, 0, 'H' },
+            { "n-best",       required_argument, 0, 'n' },
+            { 0,              0,                 0,  0 }
+        };
+
         int option_index = 0;
         c = getopt_long(argc, argv, "hVvqsP:X:H:n:", long_options, &option_index);
 
@@ -439,38 +390,35 @@ int main(int argc, char **argv)
             print_usage();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'V':
             print_version();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'v':
             verbose = true;
             quiet = false;
             break;
-          
+
         case 'P':
             profile_file = fopen(optarg, "a");
-            if (NULL == profile_file)
-              {
+            if (NULL == profile_file) {
                 perror("Couldn't open profiling file for append");
-              }
+            }
             profile_start = clock();
             break;
         case 'X':
             statistics_file = fopen(optarg, "w");
-            if (NULL == statistics_file)
-              {
+            if (NULL == statistics_file) {
                 perror("Couldn't open statistic file for writing");
-              }
+            }
             break;
         case 'H':
             histogram_file = fopen(optarg, "w");
-            if (NULL == histogram_file)
-              {
+            if (NULL == histogram_file) {
                 perror("Couldn't open histogram file for wriitng");
-              }
+            }
             break;
         case 'q': // fallthrough
         case 's':
@@ -480,10 +428,9 @@ int main(int argc, char **argv)
         case 'n':
             char* endptr;
             max_results = strtoul(optarg, &endptr, 10L);
-            if (*endptr != '\0')
-              {
+            if (*endptr != '\0') {
                 perror("argument not valid for n-best");
-              }
+            }
             break;
         default:
             std::cerr << "Invalid option\n\n";
@@ -494,25 +441,20 @@ int main(int argc, char **argv)
     }
 #else
     int optind = 1;
-#endif
-    // no more options, we should now be at the input filenames
-    if (optind == (argc - 1))
-      {
+#endif // if HAVE_GETOPT_H
+       // no more options, we should now be at the input filenames
+    if (optind == (argc - 1)) {
         zhfst_spell(argv[optind]);
-      }
-    else if (optind < (argc - 1))
-      {
+    } else if (optind < (argc - 1)) {
         fprintf(stderr, "No more than one free parameter allowed\n");
         print_short_help();
         return EXIT_FAILURE;
-      }
-    else if (optind >= argc)
-      {
-        fprintf(stderr ,"Give full path to zhfst spellers\n");
+    } else if (optind >= argc) {
+        fprintf(stderr, "Give full path to zhfst spellers\n");
         print_short_help();
         return EXIT_FAILURE;
-      }
+    }
     hfst_print_profile_line();
     print_statistics();
     return EXIT_SUCCESS;
-  }
+}

--- a/main-norvig.cc
+++ b/main-norvig.cc
@@ -1,23 +1,23 @@
 /*
-  
-  Copyright 2009 University of Helsinki
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-  http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  
-*/
+ *
+ * Copyright 2009 University of Helsinki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /*
-  This is a toy commandline utility for testing spellers on standard io.
+ * This is a toy commandline utility for testing spellers on standard io.
  */
 
 #include "ospell.h"
@@ -32,30 +32,30 @@
 bool print_usage(void)
 {
     std::cerr <<
-    "\n" <<
-    "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
-    "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
-    "print corrected output\n" <<
-    "\n" <<
-    "  -h, --help                  Print this help message\n" <<
-    "  -V, --version               Print version information\n" <<
-    "  -v, --verbose               Be verbose\n" <<
-    "  -q, --quiet                 Don't be verbose (default)\n" <<
-    "  -s, --silent                Same as quiet\n" <<
-    "\n" <<
-    "\n" <<
-    "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
-    "\n";
+        "\n" <<
+        "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
+        "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
+        "print corrected output\n" <<
+        "\n" <<
+        "  -h, --help                  Print this help message\n" <<
+        "  -V, --version               Print version information\n" <<
+        "  -v, --verbose               Be verbose\n" <<
+        "  -q, --quiet                 Don't be verbose (default)\n" <<
+        "  -s, --silent                Same as quiet\n" <<
+        "\n" <<
+        "\n" <<
+        "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
+        "\n";
     return true;
 }
 
 bool print_version(void)
 {
     std::cerr <<
-    "\n" <<
-    PACKAGE_STRING << std::endl <<
-    __DATE__ << " " __TIME__ << std::endl <<
-    "copyright (C) 2009 University of Helsinki\n";
+        "\n" <<
+        PACKAGE_STRING << std::endl <<
+        __DATE__ << " " __TIME__ << std::endl <<
+        "copyright (C) 2009 University of Helsinki\n";
     return true;
 }
 
@@ -65,28 +65,27 @@ bool print_short_help(void)
     return true;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
 
-    FILE * mutator_file = NULL;
-    FILE * lexicon_file = NULL;
-    
+    FILE* mutator_file = NULL;
+    FILE* lexicon_file = NULL;
+
     int c;
     bool verbose = false;
 
-    while (true) 
-      {
+    while (true) {
         static struct option long_options[] =
         {
-        // first the hfst-mandated options
-        {"help",         no_argument,       0, 'h'},
-        {"version",      no_argument,       0, 'V'},
-        {"verbose",      no_argument,       0, 'v'},
-        {"quiet",        no_argument,       0, 'q'},
-        {"silent",       no_argument,       0, 's'},
-        {0,              0,                 0,  0 }
+            // first the hfst-mandated options
+            { "help",         no_argument,       0, 'h' },
+            { "version",      no_argument,       0, 'V' },
+            { "verbose",      no_argument,       0, 'v' },
+            { "quiet",        no_argument,       0, 'q' },
+            { "silent",       no_argument,       0, 's' },
+            { 0,              0,                 0,  0 }
         };
-      
+
         int option_index = 0;
         c = getopt_long(argc, argv, "hVvqs", long_options, &option_index);
 
@@ -98,20 +97,20 @@ int main(int argc, char **argv)
             print_usage();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'V':
             print_version();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'v':
             verbose = true;
             break;
-          
+
         case 'q': // fallthrough
         case 's':
             break;
-          
+
         default:
             std::cerr << "Invalid option\n\n";
             print_short_help();
@@ -123,26 +122,25 @@ int main(int argc, char **argv)
     if ( (optind + 2) < argc) {
         std::cerr << "More than two input files given\n";
         return EXIT_FAILURE;
-    } else if ( (optind + 2) > argc)
-    {
+    } else if ( (optind + 2) > argc) {
         std::cerr << "Need two input files\n";
         return EXIT_FAILURE;
     } else {
         mutator_file = fopen(argv[(optind)], "r");
         if (mutator_file == NULL) {
             std::cerr << "Could not open file " << argv[(optind)]
-                  << std::endl;
+                      << std::endl;
             return 1;
         }
         lexicon_file = fopen(argv[(optind + 1)], "r");
         if (lexicon_file == NULL) {
             std::cerr << "Could not open file " << argv[(optind + 1)]
-                  << std::endl;
+                      << std::endl;
             return 1;
         }
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
+    hfst_ol::Transducer* mutator;
+    hfst_ol::Transducer* lexicon;
     mutator = new hfst_ol::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
@@ -153,27 +151,27 @@ int main(int argc, char **argv)
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    
-    hfst_ol::Speller * speller;
+
+    hfst_ol::Speller* speller;
 
     try {
         speller = new hfst_ol::Speller(mutator, lexicon);
     } catch (hfst_ol::AlphabetTranslationException& e) {
         std::cerr <<
-        "Unable to build speller - symbol " << e.what() << " not "
-        "present in lexicon's alphabet\n";
+            "Unable to build speller - symbol " << e.what() << " not "
+            "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
     }
-    
-    char * str = (char*) malloc(2000);
+
+    char* str = (char*) malloc(2000);
     // def spelltest(tests, bias=None, verbose=False):
     // n, bad, unknown, start = 0, 0, 0, time.clock()
     unsigned long n = 0;
     unsigned long bad = 0;
     unsigned long unknown = 0;
     clock_t start = clock();
-        //    if bias:
-        //        for target in tests: NWORDS[target] += bias
+    //    if bias:
+    //        for target in tests: NWORDS[target] += bias
     // for target,wrongs in tests.items():
     //    for wrong in wrongs.split():
     while (!std::cin.eof()) {
@@ -181,7 +179,7 @@ int main(int argc, char **argv)
         if (str[0] == '\0') {
             continue;
         }
-            // n += 1
+        // n += 1
         n++;
         char* p = strdup(str);
         char* tok = strtok(p, "\t");
@@ -192,70 +190,57 @@ int main(int argc, char **argv)
         //w = correct(wrong)
         char* corr = strdup(tok);
         // unknown += (corr in NWORDS)
-        if (!speller->check(corr))
-          {
+        if (!speller->check(corr)) {
             unknown++;
-          }
-        if (speller->check(mispelt))
-          {
+        }
+        if (speller->check(mispelt)) {
             // real word spelling error
             bad++;
-            if (verbose)
-              {
+            if (verbose) {
                 fprintf(stdout, "correct(%s) => %s; expected %s\n",
                         mispelt, mispelt, corr);
-              }
-          }
-        else
-          {
+            }
+        } else {
 
             hfst_ol::CorrectionQueue corrections = speller->correct(mispelt);
-            if (corrections.size() == 0)
-              {
+            if (corrections.size() == 0) {
                 bad++;
-                if (verbose)
-                  {
+                if (verbose) {
                     fprintf(stdout, "correct(%s) => %s; expected %s\n",
                             mispelt, mispelt, corr);
-                  }
-              }
-            else
-              {
+                }
+            } else {
                 std::string first = corrections.top().first;
                 //if w!=target:
-                if (first != corr)
-                  {
+                if (first != corr) {
                     //bad += 1
                     bad++;
                     // if verbose:
                     //     print 'correct(%r) => %r (%d); expected %r (%d)' % (
                     //         wrong, w, NWORDS[w], target, NWORDS[target])
-                    if (verbose)
-                      {
+                    if (verbose) {
                         fprintf(stdout, "correct(%s) => %s; "
                                 "expected %s\n",
                                 mispelt, first.c_str(),
                                 corr);
-                      }
-                  } // first != corr
-                else
-                  {
-                    if (verbose)
-                      {
+                    }
+                } // first != corr
+                else {
+                    if (verbose) {
                         fprintf(stdout, "correct(%s) => %s "
                                 "as expected %s\n",
                                 mispelt, first.c_str(),
                                 corr);
-                      }
-                  }
-              } // corrections size != 0
-          } // word not in dictionary§
-      }
-    //return dict(bad=bad, n=n, bias=bias, pct=int(100. - 100.*bad/n), 
+                    }
+                }
+            } // corrections size != 0
+        } // word not in dictionary§
+    }
+    //return dict(bad=bad, n=n, bias=bias, pct=int(100. - 100.*bad/n),
     //            unknown=unknown, secs=int(time.clock()-start) )
-    int pct = (int)round(100.0f - 100.0f*(float)bad/(float)n);
-    float secs = (((float)clock()-(float)start)/(float)CLOCKS_PER_SEC);
-    fprintf(stdout, 
+    int pct = (int) round(100.0f - 100.0f * (float) bad / (float) n);
+    float secs = (((float) clock() - (float) start) / (float) CLOCKS_PER_SEC);
+    fprintf(stdout,
             "{'bad': %lu, 'bias': None, 'unknown': %lu, "
             "'secs': %f, 'pct': %d, 'n': %lu}\n",
             bad, unknown, secs, pct, n);

--- a/main-survey.cc
+++ b/main-survey.cc
@@ -1,23 +1,23 @@
 /*
-  
-  Copyright 2009 University of Helsinki
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-  http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  
-*/
+ *
+ * Copyright 2009 University of Helsinki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /*
-  This is a toy commandline utility for testing spellers on standard io.
+ * This is a toy commandline utility for testing spellers on standard io.
  */
 
 
@@ -67,25 +67,25 @@ bool
 print_usage(void)
 {
     std::cerr <<
-    "\n" <<
-    "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
-    "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
-    "print corrected output\n" <<
-    "\n" <<
-    "  -h, --help                  Print this help message\n" <<
-    "  -V, --version               Print version information\n" <<
-    "  -v, --verbose               Be verbose\n" <<
-    "  -q, --quiet                 Don't be verbose (default)\n" <<
-    "  -s, --silent                Same as quiet\n" <<
-    "  -P, --profile=PFILE         Save profiling data to PFILE\n" <<
-    "  -X, --statistics=SFILE      Save statistsics to SFILE\n" <<
-    "  -H, --histogram=HFILE       Save match numbes to HFILE\n" <<
-    "  -n, --n-best=NBEST          Collect and provide only NBEST suggestions\n"
-    <<
-    "\n" <<
-    "\n" <<
-    "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
-    "\n";
+        "\n" <<
+        "Usage: " << PACKAGE_NAME << " [OPTIONS] ERRORSOURCE LEXICON\n" <<
+        "Run a composition of ERRORSOURCE and LEXICON on standard input and\n" <<
+        "print corrected output\n" <<
+        "\n" <<
+        "  -h, --help                  Print this help message\n" <<
+        "  -V, --version               Print version information\n" <<
+        "  -v, --verbose               Be verbose\n" <<
+        "  -q, --quiet                 Don't be verbose (default)\n" <<
+        "  -s, --silent                Same as quiet\n" <<
+        "  -P, --profile=PFILE         Save profiling data to PFILE\n" <<
+        "  -X, --statistics=SFILE      Save statistsics to SFILE\n" <<
+        "  -H, --histogram=HFILE       Save match numbes to HFILE\n" <<
+        "  -n, --n-best=NBEST          Collect and provide only NBEST suggestions\n"
+              <<
+        "\n" <<
+        "\n" <<
+        "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
+        "\n";
     return true;
 }
 
@@ -93,10 +93,10 @@ bool
 print_version(void)
 {
     std::cerr <<
-    "\n" <<
-    PACKAGE_STRING << std::endl <<
-    __DATE__ << " " __TIME__ << std::endl <<
-    "copyright (C) 2009 - 2011 University of Helsinki\n";
+        "\n" <<
+        PACKAGE_STRING << std::endl <<
+        __DATE__ << " " __TIME__ << std::endl <<
+        "copyright (C) 2009 - 2011 University of Helsinki\n";
     return true;
 }
 
@@ -112,17 +112,17 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
     FILE* mutator_file = fopen(errmodel_filename, "r");
     if (mutator_file == NULL) {
         std::cerr << "Could not open file " << errmodel_filename
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
     }
     FILE* lexicon_file = fopen(acceptor_filename, "r");
     if (lexicon_file == NULL) {
         std::cerr << "Could not open file " << acceptor_filename
-              << std::endl;
+                  << std::endl;
         return EXIT_FAILURE;
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
+    hfst_ol::Transducer* mutator;
+    hfst_ol::Transducer* lexicon;
     mutator = new hfst_ol::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
@@ -133,190 +133,153 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    
-    hfst_ol::Speller * speller;
+
+    hfst_ol::Speller* speller;
 
     try {
         speller = new hfst_ol::Speller(mutator, lexicon);
     } catch (hfst_ol::AlphabetTranslationException& e) {
         std::cerr <<
-        "Unable to build speller - symbol " << e.what() << " not "
-        "present in lexicon's alphabet\n";
+            "Unable to build speller - symbol " << e.what() << " not "
+            "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
     }
-    char * str = (char*) malloc(2000);
-   
-    char* always_incorrect = strdup("\001\002@ALWAYS INCORRECT@"); 
+    char* str = (char*) malloc(2000);
+
+    char* always_incorrect = strdup("\001\002@ALWAYS INCORRECT@");
     bool correcting = false;
     while (!std::cin.eof()) {
         std::cin.getline(str, 2000);
-        if (str[0] == '\0') 
-          {
+        if (str[0] == '\0') {
             std::cerr << "Skipping empty lines" << std::endl;
             continue;
-          }
-        if (str[strlen(str) - 1] == '\r')
-          {
+        }
+        if (str[strlen(str) - 1] == '\r') {
             std::cerr << "There is a WINDOWS linebreak in this file" <<
                 std::endl <<
                 "Please convert with dos2unix or fromdos" << std::endl;
             exit(1);
-          }
+        }
         char* tab = strchr(str, '\t');
         char* correct = 0;
-        if (tab != NULL)
-          {
+        if (tab != NULL) {
             *tab = '\0';
             correct = strdup(tab + 1);
             char* p = correct;
-            while (*p != '\0')
-              {
+            while (*p != '\0') {
                 p++;
-                if (*p == '\n')
-                  {
+                if (*p == '\n') {
                     *p = '\0';
-                  }
-              }
+                }
+            }
             correcting = true;
-          }
-        else
-          {
+        } else {
             correct = always_incorrect;
             correcting = false;
-          }
-        if (verbose)
-          {
+        }
+        if (verbose) {
             fprintf(stdout, "Checking if %s == %s\n", str, correct);
-          }
-        else
-          {
+        } else {
             fprintf(stdout, "%s", str);
-          }
+        }
         lines++;
         int i = 0;
         bool any_corrects = false;
-        if (speller->check(str)) 
-          {
+        if (speller->check(str)) {
             // spelling correct string is as if one suggestion was
             // made at edit 0 for means of this article;
             i++;
-            if (strcmp(str, correct) == 0)
-              {
+            if (strcmp(str, correct) == 0) {
                 corrects_at[i]++;
                 any_corrects = true;
-              }
+            }
             results[i]++;
             in_language++;
-            if (verbose)
-              {
+            if (verbose) {
                 fprintf(stdout, "%s was in the lexicon\n", str);
-              }
-            else
-              {
+            } else {
                 fprintf(stdout, "\t%s\n", str);
-              }
-          }
+            }
+        }
         hfst_ol::CorrectionQueue corrections = speller->correct(str /*,
-                                                                max_results */);
-        while (corrections.size() > 0)
-          {
+                                                                     * max_results */);
+        while (corrections.size() > 0) {
             i++;
-            if (i >= check_results)
-              {
+            if (i >= check_results) {
                 break;
-              }
-            if (verbose)
-              {
-                fprintf(stdout, "Trying %s\n", 
+            }
+            if (verbose) {
+                fprintf(stdout, "Trying %s\n",
                         corrections.top().first.c_str());
-              }
-            else
-              {
+            } else {
                 fprintf(stdout, "\t%s",
-                    corrections.top().first.c_str());
-              }
-            if (strcmp(corrections.top().first.c_str(), correct) == 0)
-              {
-                if (i >= max_results)
-                  {
-                    if (verbose)
-                      {
+                        corrections.top().first.c_str());
+            }
+            if (strcmp(corrections.top().first.c_str(), correct) == 0) {
+                if (i >= max_results) {
+                    if (verbose) {
                         fprintf(stdout, "%d was correct beyond threshold\n", i);
-                      }
+                    }
                     corrects_beyond++;
-                  }
-                else
-                  {
-                    if (verbose)
-                      {
+                } else {
+                    if (verbose) {
                         fprintf(stdout, "%d was correct\n", i);
-                      }
+                    }
                     corrects_at[i]++;
-                  }
+                }
                 any_corrects = true;
-              }
+            }
             corrections.pop();
-          }
-        if (!any_corrects)
-          {
+        }
+        if (!any_corrects) {
             no_corrects++;
-            if (verbose)
-              {
+            if (verbose) {
                 fprintf(stdout, "no corrects for %s ?= %s\n", str, correct);
-              }
-          }
+            }
+        }
         fprintf(stdout, "\n");
-        if (i >= max_results)
-          {
+        if (i >= max_results) {
             results_beyond++;
-          }
-        else
-          {
+        } else {
             results[i]++;
-          }
-        if (!speller->check(correct))
-          {
-            if (verbose)
-              {
+        }
+        if (!speller->check(correct)) {
+            if (verbose) {
                 fprintf(stdout, "could not have been corrected, missing %s\n",
                         correct);
-              }
+            }
             correct_not_in_lm++;
-          }
-        if (correcting)
-          {
+        }
+        if (correcting) {
             free(correct);
-          }
-      } 
+        }
+    }
     return EXIT_SUCCESS;
 
 }
 
 void
 hfst_print_profile_line()
-  {
-    if (profile_file == 0)
-      {
+{
+    if (profile_file == 0) {
         return;
-      }
-    if (ftell(profile_file) == 0L)
-      {
+    }
+    if (ftell(profile_file) == 0L) {
         fprintf(profile_file, "name\tclock\t"
                 "utime\tstime\tmaxrss\tixrss\tidrss\tisrss\t"
                 "minflt\tmajflt\tnswap\tinblock\toublock\t"
                 "msgsnd\tmsgrcv\tnsignals\tnvcsw\tnivcsw\n");
-      }
+    }
 
     fprintf(profile_file, "ospell");
     profile_end = clock();
-    fprintf(profile_file, "\t%f", ((float)(profile_end - profile_start))
-                                               / CLOCKS_PER_SEC);
+    fprintf(profile_file, "\t%f", ((float) (profile_end - profile_start))
+            / CLOCKS_PER_SEC);
     struct rusage* usage = static_cast<struct rusage*>
-        (malloc(sizeof(struct rusage)));
+                           (malloc(sizeof(struct rusage)));
     errno = 0;
     int rv = getrusage(RUSAGE_SELF, usage);
-    if (rv != -1)
-      {
+    if (rv != -1) {
         fprintf(profile_file, "\t%lu.%lu\t%lu.%lu"
                 "\t%ld\t%ld\t%ld"
                 "\t%ld"
@@ -330,41 +293,35 @@ hfst_print_profile_line()
                 usage->ru_maxrss, usage->ru_ixrss, usage->ru_idrss,
                 usage->ru_isrss,
                 usage->ru_minflt, usage->ru_majflt, usage->ru_nswap,
-                usage->ru_inblock, usage->ru_oublock, 
+                usage->ru_inblock, usage->ru_oublock,
                 usage->ru_msgsnd, usage->ru_msgrcv,
                 usage->ru_nsignals,
                 usage->ru_nvcsw, usage->ru_nivcsw);
-      }
-    else
-      {
+    } else {
         fprintf(profile_file, "\tgetrusage: %s", strerror(errno));
-      }
+    }
     fprintf(profile_file, "\n");
-  }
+}
 
 void
 print_statistics()
-  {
-    if (NULL == statistics_file)
-      {
+{
+    if (NULL == statistics_file) {
         return;
-      }
-    if (lines == 0)
-      {
+    }
+    if (lines == 0) {
         fprintf(stderr, "DATOISSA VIRHE. END.\n");
         exit(1);
-      }
+    }
     // calculate stuff
     unsigned long corrects_rest = 0;
     unsigned long total_results = 0;
-    for (int i = 6; i < max_results; i++)
-      {
+    for (int i = 6; i < max_results; i++) {
         corrects_rest += corrects_at[i];
-      }
-    for (int i = 0; i < max_results; i++)
-      {
+    }
+    for (int i = 0; i < max_results; i++) {
         total_results += results[i] * i;
-      }
+    }
     some_results = lines - results[0];
     fixable_lines = lines - correct_not_in_lm;
     // print
@@ -396,42 +353,40 @@ print_statistics()
             static_cast<float>(corrects_at[5]) / static_cast<float>(fixable_lines) * 100.0f,
             static_cast<float>(corrects_rest) / static_cast<float>(fixable_lines) * 100.0f,
             static_cast<float>(no_corrects - correct_not_in_lm) / static_cast<float>(fixable_lines) * 100.0f);
-    if (histogram_file == NULL)
-      {
+    if (histogram_file == NULL) {
         return;
-      }
+    }
     fprintf(histogram_file, "Result count\tfrequency\n");
-    for (int i = 0; i < max_results; i++)
-      {
+    for (int i = 0; i < max_results; i++) {
         fprintf(histogram_file, "%u\t%lu\n", i, results[i]);
-      }
-  }
+    }
+}
 
-int main(int argc, char **argv)
-  {
+int main(int argc, char** argv)
+{
     results = new long[max_results];
     corrects_at = new long[max_results];
-    
+
     int c;
     //std::locale::global(std::locale(""));
-  
+
 #if HAVE_GETOPT_H
     while (true) {
         static struct option long_options[] =
-            {
+        {
             // first the hfst-mandated options
-            {"help",         no_argument,       0, 'h'},
-            {"version",      no_argument,       0, 'V'},
-            {"verbose",      no_argument,       0, 'v'},
-            {"quiet",        no_argument,       0, 'q'},
-            {"silent",       no_argument,       0, 's'},
-            {"profile",      required_argument, 0, 'P'},
-            {"statistics",   required_argument, 0, 'X'},
-            {"histogram",    required_argument, 0, 'H'},
-            {"n-best",       required_argument, 0, 'n'},
-            {0,              0,                 0,  0 }
-            };
-          
+            { "help",         no_argument,       0, 'h' },
+            { "version",      no_argument,       0, 'V' },
+            { "verbose",      no_argument,       0, 'v' },
+            { "quiet",        no_argument,       0, 'q' },
+            { "silent",       no_argument,       0, 's' },
+            { "profile",      required_argument, 0, 'P' },
+            { "statistics",   required_argument, 0, 'X' },
+            { "histogram",    required_argument, 0, 'H' },
+            { "n-best",       required_argument, 0, 'n' },
+            { 0,              0,                 0,  0 }
+        };
+
         int option_index = 0;
         c = getopt_long(argc, argv, "hVvqsP:X:H:n:", long_options, &option_index);
 
@@ -443,38 +398,35 @@ int main(int argc, char **argv)
             print_usage();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'V':
             print_version();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'v':
             verbose = true;
             quiet = false;
             break;
-          
+
         case 'P':
             profile_file = fopen(optarg, "a");
-            if (NULL == profile_file)
-              {
+            if (NULL == profile_file) {
                 perror("Couldn't open profiling file for append");
-              }
+            }
             profile_start = clock();
             break;
         case 'X':
             statistics_file = fopen(optarg, "w");
-            if (NULL == statistics_file)
-              {
+            if (NULL == statistics_file) {
                 perror("Couldn't open statistic file for writing");
-              }
+            }
             break;
         case 'H':
             histogram_file = fopen(optarg, "w");
-            if (NULL == histogram_file)
-              {
+            if (NULL == histogram_file) {
                 perror("Couldn't open histogram file for wriitng");
-              }
+            }
             break;
         case 'q': // fallthrough
         case 's':
@@ -484,10 +436,9 @@ int main(int argc, char **argv)
         case 'n':
             char* endptr;
             max_results = strtoul(optarg, &endptr, 10L);
-            if (*endptr != '\0')
-              {
+            if (*endptr != '\0') {
                 perror("argument not valid for n-best");
-              }
+            }
             break;
         default:
             std::cerr << "Invalid option\n\n";
@@ -498,26 +449,21 @@ int main(int argc, char **argv)
     }
 #else
     int optind = 1;
-#endif
-    // no more options, we should now be at the input filenames
-    if (optind == (argc - 2))
-      {
-        legacy_spell(argv[optind], argv[optind+1]);
-      }
-    else if (optind < (argc - 2))
-      {
+#endif // if HAVE_GETOPT_H
+       // no more options, we should now be at the input filenames
+    if (optind == (argc - 2)) {
+        legacy_spell(argv[optind], argv[optind + 1]);
+    } else if (optind < (argc - 2)) {
         std::cerr << "No more than two free parameters allowed" << std::endl;
         print_short_help();
         return EXIT_FAILURE;
-      }
-    else if (optind >= argc)
-      {
+    } else if (optind >= argc) {
         std::cerr << "Give full path to zhfst spellers or two automata"
-            << std::endl;
+                  << std::endl;
         print_short_help();
         return EXIT_FAILURE;
-      }
+    }
     hfst_print_profile_line();
     print_statistics();
     return EXIT_SUCCESS;
-  }
+}

--- a/main.cc
+++ b/main.cc
@@ -1,23 +1,23 @@
 /*
-  
-  Copyright 2009 University of Helsinki
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-  http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  
-*/
+ *
+ * Copyright 2009 University of Helsinki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /*
-  This is a toy commandline utility for testing spellers on standard io.
+ * This is a toy commandline utility for testing spellers on standard io.
  */
 
 
@@ -53,7 +53,7 @@ static float time_cutoff = 0.0;
 static std::string error_model_filename = "";
 static std::string lexicon_filename = "";
 #ifdef WINDOWS
-  static bool output_to_console = false;
+static bool output_to_console = false;
 #endif
 static bool suggest = false;
 static bool suggest_reals = false;
@@ -61,98 +61,94 @@ static bool suggest_reals = false;
 #ifdef WINDOWS
 static std::string wide_string_to_string(const std::wstring & wstr)
 {
-  int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)§wstr.size(), NULL, 0, NULL, NULL);
-  std::string str( size_needed, 0 );
-  WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &str[0], size_needed, NULL, NULL);
-  return str;
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) wstr.size(), NULL, 0, NULL, NULL);
+    std::string str(size_needed, 0);
+    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) wstr.size(), &str[0], size_needed, NULL, NULL);
+    return str;
 }
 #endif
 
-static int hfst_fprintf(FILE * stream, const char * format, ...)
+static int hfst_fprintf(FILE* stream, const char* format, ...)
 {
-  va_list args;
-  va_start(args, format);
+    va_list args;
+    va_start(args, format);
 #ifdef WINDOWS
-  if (output_to_console && (stream == stdout || stream == stderr))
-    {
-      char buffer [1024];
-      int r = vsprintf(buffer, format, args);
-      va_end(args);
-      if (r < 0)
-        return r;
-      HANDLE stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-      if (stream == stderr)
-        stdHandle = GetStdHandle(STD_ERROR_HANDLE);
+    if (output_to_console && (stream == stdout || stream == stderr)) {
+        char buffer [1024];
+        int r = vsprintf(buffer, format, args);
+        va_end(args);
+        if (r < 0)
+            return r;
+        HANDLE stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (stream == stderr)
+            stdHandle = GetStdHandle(STD_ERROR_HANDLE);
 
-      std::string pstr(buffer);
-      DWORD numWritten = 0;
+        std::string pstr(buffer);
+        DWORD numWritten = 0;
         int wchars_num =
-          MultiByteToWideChar(CP_UTF8 , 0 , pstr.c_str() , -1, NULL , 0 );
+            MultiByteToWideChar(CP_UTF8, 0, pstr.c_str(), -1, NULL, 0);
         wchar_t* wstr = new wchar_t[wchars_num];
-        MultiByteToWideChar(CP_UTF8 , 0 ,
-                            pstr.c_str() , -1, wstr , wchars_num );
-        int retval = WriteConsoleW(stdHandle, wstr, wchars_num-1, &numWritten, NULL);
+        MultiByteToWideChar(CP_UTF8, 0,
+                            pstr.c_str(), -1, wstr, wchars_num);
+        int retval = WriteConsoleW(stdHandle, wstr, wchars_num - 1, &numWritten, NULL);
         delete[] wstr;
 
         return retval;
-    }
-  else
-    {
-      int retval = vfprintf(stream, format, args);
-      va_end(args);
-      return retval;
+    } else {
+        int retval = vfprintf(stream, format, args);
+        va_end(args);
+        return retval;
     }
 #else
-  errno = 0;
-  int retval = vfprintf(stream, format, args);
-  if (retval < 0)
-    {
-      perror("hfst_fprintf");
+    errno = 0;
+    int retval = vfprintf(stream, format, args);
+    if (retval < 0) {
+        perror("hfst_fprintf");
     }
-  va_end(args);
-  return retval;
-#endif
+    va_end(args);
+    return retval;
+#endif // ifdef WINDOWS
 }
 
 
 bool print_usage(void)
 {
     std::cout <<
-    "\n" <<
-    "Usage: " << PACKAGE_NAME << " [OPTIONS] [ZHFST-ARCHIVE]\n" <<
-    "Use automata in ZHFST-ARCHIVE or from OPTIONS to check and correct\n"
-    "\n" <<
-    "  -h, --help                Print this help message\n" <<
-    "  -V, --version             Print version information\n" <<
-    "  -v, --verbose             Be verbose\n" <<
-    "  -q, --quiet               Don't be verbose (default)\n" <<
-    "  -s, --silent              Same as quiet\n" <<
-    "  -a, --analyse             Analyse strings and corrections\n" <<
-    "  -n, --limit=N             Show at most N suggestions\n" <<
-    "  -w, --max-weight=W        Suppress corrections with weights above W\n" <<
-    "  -b, --beam=W              Suppress corrections worse than best candidate by more than W\n" <<
-    "  -t, --time-cutoff=T       Stop trying to find better corrections after T seconds (T is a float)\n" <<
-    "  -S, --suggest             Suggest corrections to mispellings\n" <<
-    "  -X, --real-word           Also suggest corrections to correct words\n" <<
-    "  -m, --error-model         Use this error model (must also give lexicon as option)\n" <<
-    "  -l, --lexicon             Use this lexicon (must also give erro model as option)\n" <<
+        "\n" <<
+        "Usage: " << PACKAGE_NAME << " [OPTIONS] [ZHFST-ARCHIVE]\n" <<
+        "Use automata in ZHFST-ARCHIVE or from OPTIONS to check and correct\n"
+        "\n" <<
+        "  -h, --help                Print this help message\n" <<
+        "  -V, --version             Print version information\n" <<
+        "  -v, --verbose             Be verbose\n" <<
+        "  -q, --quiet               Don't be verbose (default)\n" <<
+        "  -s, --silent              Same as quiet\n" <<
+        "  -a, --analyse             Analyse strings and corrections\n" <<
+        "  -n, --limit=N             Show at most N suggestions\n" <<
+        "  -w, --max-weight=W        Suppress corrections with weights above W\n" <<
+        "  -b, --beam=W              Suppress corrections worse than best candidate by more than W\n" <<
+        "  -t, --time-cutoff=T       Stop trying to find better corrections after T seconds (T is a float)\n" <<
+        "  -S, --suggest             Suggest corrections to mispellings\n" <<
+        "  -X, --real-word           Also suggest corrections to correct words\n" <<
+        "  -m, --error-model         Use this error model (must also give lexicon as option)\n" <<
+        "  -l, --lexicon             Use this lexicon (must also give erro model as option)\n" <<
 #ifdef WINDOWS
     "  -k, --output-to-console   Print output to console (Windows-specific)" <<
 #endif
     "\n" <<
-    "\n" <<
-    "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
-    "\n";
+        "\n" <<
+        "Report bugs to " << PACKAGE_BUGREPORT << "\n" <<
+        "\n";
     return true;
 }
 
 bool print_version(void)
 {
     std::cout <<
-    "\n" <<
-    PACKAGE_STRING << std::endl <<
-    __DATE__ << " " __TIME__ << std::endl <<
-    "copyright (C) 2009 - 2016 University of Helsinki\n";
+        "\n" <<
+        PACKAGE_STRING << std::endl <<
+        __DATE__ << " " __TIME__ << std::endl <<
+        "copyright (C) 2009 - 2016 University of Helsinki\n";
     return true;
 }
 
@@ -164,184 +160,156 @@ bool print_short_help(void)
 
 void
 do_suggest(ZHfstOspeller& speller, const std::string& str)
-  {
+{
     hfst_ol::CorrectionQueue corrections = speller.suggest(str);
-    if (corrections.size() > 0) 
-    {
+    if (corrections.size() > 0) {
         hfst_fprintf(stdout, "Corrections for \"%s\":\n", str.c_str());
-        while (corrections.size() > 0)
-          {
+        while (corrections.size() > 0) {
             const std::string& corr = corrections.top().first;
-            if (analyse)
-              {
+            if (analyse) {
                 hfst_ol::AnalysisQueue anals = speller.analyse(corr, true);
                 bool all_discarded = true;
-                while (anals.size() > 0)
-                  {
+                while (anals.size() > 0) {
                     if (anals.top().first.find("Use/SpellNoSugg") !=
-                        std::string::npos)
-                      {
+                        std::string::npos) {
                         hfst_fprintf(stdout, "%s    %f    %s    "
-                                       "[DISCARDED BY ANALYSES]\n", 
-                                       corr.c_str(), corrections.top().second,
-                                       anals.top().first.c_str());
-                      }
-                    else
-                      {
+                                     "[DISCARDED BY ANALYSES]\n",
+                                     corr.c_str(), corrections.top().second,
+                                     anals.top().first.c_str());
+                    } else {
                         all_discarded = false;
                         hfst_fprintf(stdout, "%s    %f    %s\n",
-                                       corr.c_str(), corrections.top().second,
-                                       anals.top().first.c_str());
-                      }
+                                     corr.c_str(), corrections.top().second,
+                                     anals.top().first.c_str());
+                    }
                     anals.pop();
-                  }
-                if (all_discarded)
-                  {
+                }
+                if (all_discarded) {
                     hfst_fprintf(stdout, "All corrections were "
-                                       "invalidated by analysis! "
-                                       "No score!\n");
-                  }
-              }
-            else
-              {
-                hfst_fprintf(stdout, "%s    %f\n", 
-                                   corr.c_str(), 
-                                   corrections.top().second);
-              }
+                                 "invalidated by analysis! "
+                                 "No score!\n");
+                }
+            } else {
+                hfst_fprintf(stdout, "%s    %f\n",
+                             corr.c_str(),
+                             corrections.top().second);
+            }
             corrections.pop();
-          }
+        }
         hfst_fprintf(stdout, "\n");
-      }
-    else
-      {
+    } else {
         hfst_fprintf(stdout,
-                           "Unable to correct \"%s\"!\n\n", str.c_str());
-      }
+                     "Unable to correct \"%s\"!\n\n", str.c_str());
+    }
 
-  }
+}
 
 void
 do_spell(ZHfstOspeller& speller, const std::string& str)
-  {
-    if (speller.spell(str)) 
-      {
+{
+    if (speller.spell(str)) {
         hfst_fprintf(stdout, "\"%s\" is in the lexicon...\n",
-                           str.c_str());
-        if (analyse)
-          {
+                     str.c_str());
+        if (analyse) {
             hfst_fprintf(stdout, "analysing:\n");
             hfst_ol::AnalysisQueue anals = speller.analyse(str, false);
             bool all_no_spell = true;
-            while (anals.size() > 0)
-              {
-                if (anals.top().first.find("Use/-Spell") != std::string::npos)
-                  {
+            while (anals.size() > 0) {
+                if (anals.top().first.find("Use/-Spell") != std::string::npos) {
                     hfst_fprintf(stdout,
-                                       "%s   %f [DISCARDED AS -Spell]\n",
-                                       anals.top().first.c_str(),
-                                       anals.top().second);
-                  }
-                else
-                  {
+                                 "%s   %f [DISCARDED AS -Spell]\n",
+                                 anals.top().first.c_str(),
+                                 anals.top().second);
+                } else {
                     all_no_spell = false;
                     hfst_fprintf(stdout, "%s   %f\n",
-                                   anals.top().first.c_str(),
-                                   anals.top().second);
-                  }
+                                 anals.top().first.c_str(),
+                                 anals.top().second);
+                }
                 anals.pop();
-              }
-            if (all_no_spell)
-              {
-                hfst_fprintf(stdout, 
+            }
+            if (all_no_spell) {
+                hfst_fprintf(stdout,
                              "All spellings were invalidated by analysis! "
                              ".:. Not in lexicon!\n");
-              }
-          }
-        if (suggest_reals)
-          {
+            }
+        }
+        if (suggest_reals) {
             hfst_fprintf(stdout, "(but correcting anyways)\n", str.c_str());
             do_suggest(speller, str);
-          }
-      }
-    else
-      {
+        }
+    } else {
         hfst_fprintf(stdout, "\"%s\" is NOT in the lexicon:\n",
-                           str.c_str());
-        if (suggest)
-          {
+                     str.c_str());
+        if (suggest) {
             do_suggest(speller, str);
-          }
-      }
-  }
+        }
+    }
+}
 
 int
 zhfst_spell(char* zhfst_filename)
 {
-  ZHfstOspeller speller;
-  try
+    ZHfstOspeller speller;
+    try
     {
-      speller.read_zhfst(zhfst_filename);
+        speller.read_zhfst(zhfst_filename);
     }
-  catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
+    catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
     {
-      hfst_fprintf(stderr, "cannot finish reading zhfst archive %s:\n%s.\n", 
-                         zhfst_filename, zhmdpe.what());
-      //std::cerr << "cannot finish reading zhfst archive " << zhfst_filename <<
-      //             ":\n" << zhmdpe.what() << "." << std::endl;
-      return EXIT_FAILURE;
+        hfst_fprintf(stderr, "cannot finish reading zhfst archive %s:\n%s.\n",
+                     zhfst_filename, zhmdpe.what());
+        //std::cerr << "cannot finish reading zhfst archive " << zhfst_filename <<
+        //             ":\n" << zhmdpe.what() << "." << std::endl;
+        return EXIT_FAILURE;
     }
-  catch (hfst_ol::ZHfstZipReadingError zhzre)
+    catch (hfst_ol::ZHfstZipReadingError zhzre)
     {
-      //std::cerr << "cannot read zhfst archive " << zhfst_filename << ":\n" 
-      //    << zhzre.what() << "." << std::endl
-      //    << "trying to read as legacy automata directory" << std::endl;
-      hfst_fprintf(stderr, 
-                         "cannot read zhfst archive %s:\n"
-                         "%s.\n",
-                         zhfst_filename, zhzre.what());
-      return EXIT_FAILURE;
+        //std::cerr << "cannot read zhfst archive " << zhfst_filename << ":\n"
+        //    << zhzre.what() << "." << std::endl
+        //    << "trying to read as legacy automata directory" << std::endl;
+        hfst_fprintf(stderr,
+                     "cannot read zhfst archive %s:\n"
+                     "%s.\n",
+                     zhfst_filename, zhzre.what());
+        return EXIT_FAILURE;
     }
-  catch (hfst_ol::ZHfstXmlParsingError zhxpe)
+    catch (hfst_ol::ZHfstXmlParsingError zhxpe)
     {
-      //std::cerr << "Cannot finish reading index.xml from " 
-      //  << zhfst_filename << ":" << std::endl
-      //  << zhxpe.what() << "." << std::endl;
-      hfst_fprintf(stderr, 
-                         "Cannot finish reading index.xml from %s:\n"
-                         "%s.\n", 
-                         zhfst_filename, zhxpe.what());
-      return EXIT_FAILURE;
+        //std::cerr << "Cannot finish reading index.xml from "
+        //  << zhfst_filename << ":" << std::endl
+        //  << zhxpe.what() << "." << std::endl;
+        hfst_fprintf(stderr,
+                     "Cannot finish reading index.xml from %s:\n"
+                     "%s.\n",
+                     zhfst_filename, zhxpe.what());
+        return EXIT_FAILURE;
     }
-  if (verbose)
-    {
-      //std::cout << "Following metadata was read from ZHFST archive:" << std::endl
-      //          << speller.metadata_dump() << std::endl;
-      hfst_fprintf(stdout, 
-                         "Following metadata was read from ZHFST archive:\n"
-                         "%s\n", 
-                         speller.metadata_dump().c_str());
+    if (verbose) {
+        //std::cout << "Following metadata was read from ZHFST archive:" << std::endl
+        //          << speller.metadata_dump() << std::endl;
+        hfst_fprintf(stdout,
+                     "Following metadata was read from ZHFST archive:\n"
+                     "%s\n",
+                     speller.metadata_dump().c_str());
     }
-  speller.set_queue_limit(suggs);
-  if (suggs != 0 && verbose)
-    {
-      hfst_fprintf(stdout, "Printing only %lu top suggestions per line\n", suggs);
+    speller.set_queue_limit(suggs);
+    if (suggs != 0 && verbose) {
+        hfst_fprintf(stdout, "Printing only %lu top suggestions per line\n", suggs);
     }
-  speller.set_weight_limit(max_weight);
-  if (max_weight >= 0.0 && verbose)
-  {
-      hfst_fprintf(stdout, "Not printing suggestions worse than %f\n", max_weight);
-  }
-  speller.set_beam(beam);
-  if (beam >= 0.0 && verbose)
-  {
-      hfst_fprintf(stdout, "Not printing suggestions worse than best by margin %f\n", beam);
-  }
-  speller.set_time_cutoff(time_cutoff);
-  if (time_cutoff >= 0.0 && verbose)
-  {
-      hfst_fprintf(stdout, "Not trying to find better suggestions after %f seconds\n", time_cutoff);
-  }
-  char * str = (char*) malloc(2000);
+    speller.set_weight_limit(max_weight);
+    if (max_weight >= 0.0 && verbose) {
+        hfst_fprintf(stdout, "Not printing suggestions worse than %f\n", max_weight);
+    }
+    speller.set_beam(beam);
+    if (beam >= 0.0 && verbose) {
+        hfst_fprintf(stdout, "Not printing suggestions worse than best by margin %f\n", beam);
+    }
+    speller.set_time_cutoff(time_cutoff);
+    if (time_cutoff >= 0.0 && verbose) {
+        hfst_fprintf(stdout, "Not trying to find better suggestions after %f seconds\n", time_cutoff);
+    }
+    char* str = (char*) malloc(2000);
 
 
 #ifdef WINDOWS
@@ -349,122 +317,115 @@ zhfst_spell(char* zhfst_filename)
     const HANDLE stdIn = GetStdHandle(STD_INPUT_HANDLE);
     WCHAR buffer[0x1000];
     DWORD numRead = 0;
-    while (ReadConsoleW(stdIn, buffer, sizeof buffer, &numRead, NULL))
-      {
-        std::wstring wstr(buffer, numRead-1); // skip the newline
+    while (ReadConsoleW(stdIn, buffer, sizeof buffer, &numRead, NULL)) {
+        std::wstring wstr(buffer, numRead - 1); // skip the newline
         std::string linestr = wide_string_to_string(wstr);
         free(str);
         str = strdup(linestr.c_str());
-#else    
+#else
     while (!std::cin.eof()) {
         std::cin.getline(str, 2000);
 #endif
         if (str[0] == '\0') {
             continue;
         }
-        if (str[strlen(str) - 1] == '\r')
-          {
+        if (str[strlen(str) - 1] == '\r') {
 #ifdef WINDOWS
             str[strlen(str) - 1] = '\0';
 #else
             hfst_fprintf(stderr, "There is a WINDOWS linebreak in this file\n"
-                               "Please convert with dos2unix or fromdos\n");
+                         "Please convert with dos2unix or fromdos\n");
             exit(1);
 #endif
-          }
+        }
         do_spell(speller, str);
-      }
+    }
     free(str);
     return EXIT_SUCCESS;
 }
 
 int
-    legacy_spell(hfst_ol::Speller * s)
+legacy_spell(hfst_ol::Speller* s)
 {
-      ZHfstOspeller speller;
-      speller.inject_speller(s);
-      speller.set_queue_limit(suggs);
-      if (suggs != 0 && verbose)
-      {
-          hfst_fprintf(stdout, "Printing only %lu top suggestions per line\n", suggs);
-      }
-      speller.set_weight_limit(max_weight);
-      if (max_weight >= 0.0 && verbose)
-      {
-          hfst_fprintf(stdout, "Not printing suggestions worse than %f\n", suggs);
-      }
-      speller.set_beam(beam);
-      if (beam >= 0.0 && verbose)
-      {
-          hfst_fprintf(stdout, "Not printing suggestions worse than best by margin %f\n", suggs);
-      }
-      char * str = (char*) malloc(2000);
-      
+    ZHfstOspeller speller;
+    speller.inject_speller(s);
+    speller.set_queue_limit(suggs);
+    if (suggs != 0 && verbose) {
+        hfst_fprintf(stdout, "Printing only %lu top suggestions per line\n", suggs);
+    }
+    speller.set_weight_limit(max_weight);
+    if (max_weight >= 0.0 && verbose) {
+        hfst_fprintf(stdout, "Not printing suggestions worse than %f\n", suggs);
+    }
+    speller.set_beam(beam);
+    if (beam >= 0.0 && verbose) {
+        hfst_fprintf(stdout, "Not printing suggestions worse than best by margin %f\n", suggs);
+    }
+    char* str = (char*) malloc(2000);
+
 #ifdef WINDOWS
     SetConsoleCP(65001);
     const HANDLE stdIn = GetStdHandle(STD_INPUT_HANDLE);
     WCHAR buffer[0x1000];
     DWORD numRead = 0;
-    while (ReadConsoleW(stdIn, buffer, sizeof buffer, &numRead, NULL))
-      {
-        std::wstring wstr(buffer, numRead-1); // skip the newline
+    while (ReadConsoleW(stdIn, buffer, sizeof buffer, &numRead, NULL)) {
+        std::wstring wstr(buffer, numRead - 1); // skip the newline
         std::string linestr = wide_string_to_string(wstr);
         free(str);
         str = strdup(linestr.c_str());
-#else    
+#else
     while (!std::cin.eof()) {
         std::cin.getline(str, 2000);
 #endif
         if (str[0] == '\0') {
             continue;
         }
-        if (str[strlen(str) - 1] == '\r')
-          {
+        if (str[strlen(str) - 1] == '\r') {
 #ifdef WINDOWS
             str[strlen(str) - 1] = '\0';
 #else
             hfst_fprintf(stderr, "There is a WINDOWS linebreak in this file\n"
-                               "Please convert with dos2unix or fromdos\n");
+                         "Please convert with dos2unix or fromdos\n");
             exit(1);
 #endif
-          }
+        }
         do_spell(speller, str);
     }
     free(str);
     return EXIT_SUCCESS;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-    
+
     int c;
     //std::locale::global(std::locale(""));
-  
+
 #if HAVE_GETOPT_H
     while (true) {
         static struct option long_options[] =
-            {
+        {
             // first the hfst-mandated options
-            {"help",         no_argument,       0, 'h'},
-            {"version",      no_argument,       0, 'V'},
-            {"verbose",      no_argument,       0, 'v'},
-            {"quiet",        no_argument,       0, 'q'},
-            {"silent",       no_argument,       0, 's'},
-            {"analyse",      no_argument,       0, 'a'},
-            {"limit",        required_argument, 0, 'n'},
-            {"max-weight",   required_argument, 0, 'w'},
-            {"beam",         required_argument, 0, 'b'},
-            {"suggest",      no_argument,       0, 'S'},
-            {"time-cutoff",  required_argument, 0, 't'},
-            {"real-word",    no_argument,       0, 'X'},
-            {"error-model",  required_argument, 0, 'm'},
-            {"lexicon",      required_argument, 0, 'l'},
+            { "help",         no_argument,       0, 'h' },
+            { "version",      no_argument,       0, 'V' },
+            { "verbose",      no_argument,       0, 'v' },
+            { "quiet",        no_argument,       0, 'q' },
+            { "silent",       no_argument,       0, 's' },
+            { "analyse",      no_argument,       0, 'a' },
+            { "limit",        required_argument, 0, 'n' },
+            { "max-weight",   required_argument, 0, 'w' },
+            { "beam",         required_argument, 0, 'b' },
+            { "suggest",      no_argument,       0, 'S' },
+            { "time-cutoff",  required_argument, 0, 't' },
+            { "real-word",    no_argument,       0, 'X' },
+            { "error-model",  required_argument, 0, 'm' },
+            { "lexicon",      required_argument, 0, 'l' },
 #ifdef WINDOWS
-            {"output-to-console",       no_argument,       0, 'k'},
+            { "output-to-console",       no_argument,       0, 'k' },
 #endif
-            {0,              0,                 0,  0 }
-            };
-          
+            { 0,              0,                 0,  0 }
+        };
+
         int option_index = 0;
         c = getopt_long(argc, argv, "hVvqsan:w:b:t:SXm:l:k", long_options, &option_index);
         char* endptr = 0;
@@ -477,17 +438,17 @@ int main(int argc, char **argv)
             print_usage();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'V':
             print_version();
             return EXIT_SUCCESS;
             break;
-          
+
         case 'v':
             verbose = true;
             quiet = false;
             break;
-          
+
         case 'q': // fallthrough
         case 's':
             quiet = true;
@@ -498,60 +459,48 @@ int main(int argc, char **argv)
             break;
         case 'n':
             suggs = strtoul(optarg, &endptr, 10);
-            if (endptr == optarg)
-              {
+            if (endptr == optarg) {
                 fprintf(stderr, "%s not a strtoul number\n", optarg);
                 exit(1);
-              }
-            else if (*endptr != '\0')
-              {
+            } else if (*endptr != '\0') {
                 fprintf(stderr, "%s truncated from limit parameter\n", endptr);
-              }
+            }
             break;
         case 'w':
             max_weight = strtof(optarg, &endptr);
-            if (endptr == optarg)
-            {
+            if (endptr == optarg) {
                 fprintf(stderr, "%s is not a float\n", optarg);
                 exit(1);
-              }
-            else if (*endptr != '\0')
-              {
+            } else if (*endptr != '\0') {
                 fprintf(stderr, "%s truncated from limit parameter\n", endptr);
-              }
+            }
 
             break;
         case 'b':
             beam = strtof(optarg, &endptr);
-            if (endptr == optarg)
-            {
+            if (endptr == optarg) {
                 fprintf(stderr, "%s is not a float\n", optarg);
                 exit(1);
-              }
-            else if (*endptr != '\0')
-              {
+            } else if (*endptr != '\0') {
                 fprintf(stderr, "%s truncated from limit parameter\n", endptr);
-              }
+            }
 
             break;
         case 't':
             time_cutoff = strtof(optarg, &endptr);
-            if (endptr == optarg)
-            {
+            if (endptr == optarg) {
                 fprintf(stderr, "%s is not a float\n", optarg);
                 exit(1);
-              }
-            else if (*endptr != '\0')
-              {
+            } else if (*endptr != '\0') {
                 fprintf(stderr, "%s truncated from limit parameter\n", endptr);
-              }
+            }
 
             break;
 #ifdef WINDOWS
         case 'k':
             output_to_console = true;
             break;
-#endif 
+#endif
         case 'S':
             suggest = true;
             break;
@@ -573,10 +522,9 @@ int main(int argc, char **argv)
     }
 #else
     int optind = 1;
-#endif
-    // no more options, we should now be at the input filenames
-    if (optind == (argc - 1))
-    {
+#endif // if HAVE_GETOPT_H
+       // no more options, we should now be at the input filenames
+    if (optind == (argc - 1)) {
         if (error_model_filename != "" || lexicon_filename != "") {
             std::cerr << "Give *either* a zhfst speller or --error-model and --lexicon"
                       << std::endl;
@@ -584,27 +532,23 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
         return zhfst_spell(argv[optind]);
-      }
-    else if (optind < (argc - 1))
-      {
+    } else if (optind < (argc - 1)) {
         std::cerr << "Too many file parameters" << std::endl;
         print_short_help();
         return EXIT_FAILURE;
-      }
-    else if (optind >= argc)
-      {
-          if (error_model_filename == "" || lexicon_filename == "") {
-              std::cerr << "Give *either* a zhfst speller or --error-model and --lexicon"
-                        << std::endl;
-              print_short_help();
-              return EXIT_FAILURE;
-          }
-          FILE * err_file = fopen(error_model_filename.c_str(), "r");
-          FILE * lex_file = fopen(lexicon_filename.c_str(), "r");
-          hfst_ol::Transducer err(err_file);
-          hfst_ol::Transducer lex(lex_file);
-          hfst_ol::Speller * s = new hfst_ol::Speller(&err, &lex);
-          return legacy_spell(s);
-      }
+    } else if (optind >= argc) {
+        if (error_model_filename == "" || lexicon_filename == "") {
+            std::cerr << "Give *either* a zhfst speller or --error-model and --lexicon"
+                      << std::endl;
+            print_short_help();
+            return EXIT_FAILURE;
+        }
+        FILE* err_file = fopen(error_model_filename.c_str(), "r");
+        FILE* lex_file = fopen(lexicon_filename.c_str(), "r");
+        hfst_ol::Transducer err(err_file);
+        hfst_ol::Transducer lex(lex_file);
+        hfst_ol::Speller* s = new hfst_ol::Speller(&err, &lex);
+        return legacy_spell(s);
+    }
     return EXIT_SUCCESS;
-  }
+}

--- a/ol-exceptions.h
+++ b/ol-exceptions.h
@@ -19,52 +19,55 @@ struct OspellException
     std::string file; //!< file name of exception
     size_t line;      //!< line number of exception
 
-    OspellException(void) {}
-   
-//!
-//! construct exception with name, file and location
-OspellException(const std::string &name,const std::string &file,size_t line):
-    name(name),
-    file(file),
-    line(line)
-    {}
-    
+    OspellException(void)
+    {
+    }
+
+    //!
+    //! construct exception with name, file and location
+    OspellException(const std::string &name, const std::string &file, size_t line) :
+        name(name),
+        file(file),
+        line(line)
+    {
+    }
+
     //!
     //! create string representation of exception for output
-    std::string operator() (void) const
+    std::string operator()(void) const
     {
         std::ostringstream o;
-        o << "Exception: "<< name << " in file: "
+        o << "Exception: " << name << " in file: "
           << file << " on line: " << line;
         return o.str();
     }
     //!
     //! create char array representation of exception for output
     const char* what()
-      {
+    {
         std::ostringstream o;
         o << file << ":" << line << ":" << name;
         return o.str().c_str();
-      }
+    }
 };
 
 // These macros are used instead of the normal exception facilities.
 
-#define HFST_THROW(E) throw E(#E,__FILE__,__LINE__)
+#define HFST_THROW(E) throw E(#E, __FILE__, __LINE__)
 
-#define HFST_THROW_MESSAGE(E,M) throw E(std::string(#E)+": "+std::string(M)\
-                        ,__FILE__,__LINE__)
+#define HFST_THROW_MESSAGE(E, M) throw E(std::string(#E) + ": " + std::string(M) \
+                                         , __FILE__, __LINE__)
 
 #define HFST_EXCEPTION_CHILD_DECLARATION(CHILD) \
     struct CHILD : public OspellException \
-    { CHILD(const std::string &name,const std::string &file,size_t line):\
-    OspellException(name,file,line) {}} 
+    { CHILD(const std::string & name, const std::string & file, size_t line) : \
+          OspellException(name, file, line) {} }
 
 #define HFST_CATCH(E)                           \
     catch (const E &e)                          \
     {                                   \
-    std::cerr << e.file << ", line " << e.line << ": " <<       \
-        e() << std::endl;                       \
+        std::cerr << e.file << ", line " << e.line << ": " <<       \
+            e() << std::endl;                       \
     }
 
 // Now the exceptions themselves

--- a/ospell.cc
+++ b/ospell.cc
@@ -23,7 +23,7 @@ namespace hfst_ol {
 int nByte_utf8(unsigned char c)
 {
     /* utility function to determine how many bytes to peel off as
-       a utf-8 character for representing as unknown symbol */
+     * a utf-8 character for representing as unknown symbol */
     if (c <= 127) {
         return 1;
     } else if ( (c & (128 + 64 + 32 + 16)) == (128 + 64 + 32 + 16) ) {
@@ -90,23 +90,25 @@ Weight WeightQueue::get_highest(void) const
     return back();
 }
 
-Transducer::Transducer(FILE* f):
+Transducer::Transducer(FILE* f) :
     header(TransducerHeader(f)),
     alphabet(TransducerAlphabet(f, header.symbol_count())),
     keys(alphabet.get_key_table()),
-    encoder(keys,header.input_symbol_count()),
-    indices(f,header.index_table_size()),
-    transitions(f,header.target_table_size())
-    {}
+    encoder(keys, header.input_symbol_count()),
+    indices(f, header.index_table_size()),
+    transitions(f, header.target_table_size())
+{
+}
 
-Transducer::Transducer(char* raw):
+Transducer::Transducer(char* raw) :
     header(TransducerHeader(&raw)),
     alphabet(TransducerAlphabet(&raw, header.symbol_count())),
     keys(alphabet.get_key_table()),
-    encoder(keys,header.input_symbol_count()),
-    indices(&raw,header.index_table_size()),
-    transitions(&raw,header.target_table_size())
-    {}
+    encoder(keys, header.input_symbol_count()),
+    indices(&raw, header.index_table_size()),
+    transitions(&raw, header.target_table_size())
+{
+}
 
 TreeNode TreeNode::update_lexicon(SymbolNumber symbol,
                                   TransitionTableIndex next_lexicon,
@@ -173,34 +175,34 @@ TreeNode TreeNode::update(SymbolNumber symbol,
 bool TreeNode::try_compatible_with(FlagDiacriticOperation op)
 {
     switch (op.Operation()) {
-    
+
     case P: // positive set
         flag_state[op.Feature()] = op.Value();
         return true;
-    
+
     case N: // negative set (literally, in this implementation)
-        flag_state[op.Feature()] = -1*op.Value();
+        flag_state[op.Feature()] = -1 * op.Value();
         return true;
-    
+
     case R: // require
         if (op.Value() == 0) { // "plain" require, return false if unset
             return (flag_state[op.Feature()] != 0);
         }
         return (flag_state[op.Feature()] == op.Value());
-    
+
     case D: // disallow
         if (op.Value() == 0) { // "plain" disallow, return true if unset
             return (flag_state[op.Feature()] == 0);
         }
         return (flag_state[op.Feature()] != op.Value());
-      
+
     case C: // clear
         flag_state[op.Feature()] = 0;
         return true;
-      
+
     case U: // unification
         /* if the feature is unset OR the feature is to this value already OR
-           the feature is negatively set to something else than this value */
+         * the feature is negatively set to something else than this value */
         if (flag_state[op.Feature()] == 0 ||
             flag_state[op.Feature()] == op.Value() ||
             (flag_state[op.Feature()] < 0 &&
@@ -211,28 +213,28 @@ bool TreeNode::try_compatible_with(FlagDiacriticOperation op)
         }
         return false;
     }
-    
+
     return false; // to make the compiler happy
 }
 
-Speller::Speller(Transducer* mutator_ptr, Transducer* lexicon_ptr):
-        mutator(mutator_ptr),
-        lexicon(lexicon_ptr),
-        input(),
-        queue(TreeNodeQueue()),
-        next_node(FlagDiacriticState(get_state_size(), 0)),
-        limit(std::numeric_limits<Weight>::max()),
-        alphabet_translator(SymbolVector()),
-        operations(lexicon->get_operations()),
-        limiting(None),
-        mode(Correct)
-            {
-                if (mutator != NULL) {
-                    build_alphabet_translator();
-                    cache = std::vector<CacheContainer>(
-                        mutator->get_key_table()->size(), CacheContainer());
-                }
-            }
+Speller::Speller(Transducer* mutator_ptr, Transducer* lexicon_ptr) :
+    mutator(mutator_ptr),
+    lexicon(lexicon_ptr),
+    input(),
+    queue(TreeNodeQueue()),
+    next_node(FlagDiacriticState(get_state_size(), 0)),
+    limit(std::numeric_limits<Weight>::max()),
+    alphabet_translator(SymbolVector()),
+    operations(lexicon->get_operations()),
+    limiting(None),
+    mode(Correct)
+{
+    if (mutator != NULL) {
+        build_alphabet_translator();
+        cache = std::vector<CacheContainer>(
+            mutator->get_key_table()->size(), CacheContainer());
+    }
+}
 
 
 SymbolNumber
@@ -249,7 +251,7 @@ void Speller::lexicon_epsilons(void)
     }
     TransitionTableIndex next = lexicon->next(next_node.lexicon_state, 0);
     STransition i_s = lexicon->take_epsilons_and_flags(next);
-    
+
     while (i_s.symbol != NO_SYMBOL) {
         if (is_under_weight_limit(next_node.weight + i_s.weight)) {
             if (lexicon->transitions.input_symbol(next) == 0) {
@@ -288,8 +290,8 @@ void Speller::lexicon_consume(void)
         // for the case with plain lexicon symbols
         this_input = input[input_state];
     }
-    if(!lexicon->has_transitions(
-           next_node.lexicon_state + 1, this_input)) {
+    if (!lexicon->has_transitions(
+            next_node.lexicon_state + 1, this_input)) {
         // we have no regular transitions for this
         if (this_input >= lexicon->get_alphabet()->get_orig_symbol_count()) {
             // this input was not originally in the alphabet, so unknown or identity
@@ -347,7 +349,7 @@ void Speller::mutator_epsilons(void)
     }
     TransitionTableIndex next_m = mutator->next(next_node.mutator_state, 0);
     STransition mutator_i_s = mutator->take_epsilons(next_m);
-   
+
     while (mutator_i_s.symbol != NO_SYMBOL) {
         if (mutator_i_s.symbol == 0) {
             if (is_under_weight_limit(
@@ -445,28 +447,28 @@ void Speller::queue_mutator_arcs(SymbolNumber input_sym)
             mutator_i_s = mutator->take_non_epsilons(next_m, input_sym);
             continue;
         } else if (!lexicon->has_transitions(
-                    next_node.lexicon_state + 1,
-                    alphabet_translator[mutator_i_s.symbol])) {
-                // we have no regular transitions for this
-                if (alphabet_translator[mutator_i_s.symbol] >= lexicon->get_alphabet()->get_orig_symbol_count()) {
-                    // this input was not originally in the alphabet, so unknown or identity
-                    // may apply
-                    if (lexicon->get_unknown() != NO_SYMBOL &&
-                        lexicon->has_transitions(next_node.lexicon_state + 1,
-                                                 lexicon->get_unknown())) {
-                        queue_lexicon_arcs(lexicon->get_unknown(),
-                                           mutator_i_s.index, mutator_i_s.weight, 1);
-                    }
-                    if (lexicon->get_identity() != NO_SYMBOL &&
-                        lexicon->has_transitions(next_node.lexicon_state + 1,
-                                                 lexicon->get_identity())) {
-                        queue_lexicon_arcs(lexicon->get_identity(),
-                                           mutator_i_s.index, mutator_i_s.weight, 1);
-                    }
+                       next_node.lexicon_state + 1,
+                       alphabet_translator[mutator_i_s.symbol])) {
+            // we have no regular transitions for this
+            if (alphabet_translator[mutator_i_s.symbol] >= lexicon->get_alphabet()->get_orig_symbol_count()) {
+                // this input was not originally in the alphabet, so unknown or identity
+                // may apply
+                if (lexicon->get_unknown() != NO_SYMBOL &&
+                    lexicon->has_transitions(next_node.lexicon_state + 1,
+                                             lexicon->get_unknown())) {
+                    queue_lexicon_arcs(lexicon->get_unknown(),
+                                       mutator_i_s.index, mutator_i_s.weight, 1);
                 }
-                ++next_m;
-                mutator_i_s = mutator->take_non_epsilons(next_m, input_sym);
-                continue;
+                if (lexicon->get_identity() != NO_SYMBOL &&
+                    lexicon->has_transitions(next_node.lexicon_state + 1,
+                                             lexicon->get_identity())) {
+                    queue_lexicon_arcs(lexicon->get_identity(),
+                                       mutator_i_s.index, mutator_i_s.weight, 1);
+                }
+            }
+            ++next_m;
+            mutator_i_s = mutator->take_non_epsilons(next_m, input_sym);
+            continue;
         }
         queue_lexicon_arcs(alphabet_translator[mutator_i_s.symbol],
                            mutator_i_s.index, mutator_i_s.weight, 1);
@@ -477,13 +479,13 @@ void Speller::queue_mutator_arcs(SymbolNumber input_sym)
 }
 
 bool Transducer::initialize_input_vector(SymbolVector & input_vector,
-                                         Encoder * encoder,
-                                         char * line)
+                                         Encoder* encoder,
+                                         char* line)
 {
     input_vector.clear();
     SymbolNumber k = NO_SYMBOL;
-    char ** inpointer = &line;
-    char * oldpointer;
+    char** inpointer = &line;
+    char* oldpointer;
     while (**inpointer != '\0') {
         oldpointer = *inpointer;
         k = encoder->find_key(inpointer);
@@ -497,7 +499,7 @@ bool Transducer::initialize_input_vector(SymbolVector & input_vector,
     return true;
 }
 
-AnalysisQueue Transducer::lookup(char * line)
+AnalysisQueue Transducer::lookup(char* line)
 {
     std::map<std::string, Weight> outputs;
     AnalysisQueue analyses;
@@ -517,7 +519,7 @@ AnalysisQueue Transducer::lookup(char * line)
         if (next_node.input_state == input.size() &&
             is_final(next_node.lexicon_state)) {
             Weight weight = next_node.weight +
-                final_weight(next_node.lexicon_state);
+                            final_weight(next_node.lexicon_state);
             std::string output = stringify(get_key_table(),
                                            next_node.string);
             /* if the result is novel or lower weighted than before, insert it */
@@ -553,18 +555,18 @@ AnalysisQueue Transducer::lookup(char * line)
                 i_s = take_epsilons_and_flags(next_index);
             }
         }
-        
+
         // input consumption loop
         unsigned int input_state = next_node.input_state;
         if (input_state < input.size() &&
             has_transitions(
                 next_node.lexicon_state + 1, input[input_state])) {
-            
+
             next_index = next(next_node.lexicon_state,
                               input[input_state]);
             STransition i_s = take_non_epsilons(next_index,
                                                 input[input_state]);
-            
+
             while (i_s.symbol != NO_SYMBOL) {
                 queue.push_back(next_node.update(
                                     i_s.symbol,
@@ -572,32 +574,32 @@ AnalysisQueue Transducer::lookup(char * line)
                                     next_node.mutator_state,
                                     i_s.index,
                                     i_s.weight));
-                
+
                 ++next_index;
                 i_s = take_non_epsilons(next_index, input[input_state]);
             }
         }
-        
+
     }
-    
+
     std::map<std::string, Weight>::const_iterator it;
     for (it = outputs.begin(); it != outputs.end(); ++it) {
         analyses.push(StringWeightPair(it->first, it->second));
     }
-    
+
     return analyses;
 }
 
 bool
 Transducer::final_transition(TransitionTableIndex i)
 {
-    return transitions.final(i);
+    return transitions.final (i);
 }
 
 bool
 Transducer::final_index(TransitionTableIndex i)
 {
-    return indices.final(i);
+    return indices.final (i);
 }
 
 KeyTable*
@@ -654,7 +656,7 @@ TransitionTableIndex Transducer::next(const TransitionTableIndex i,
     if (i >= TARGET_TABLE) {
         return i - TARGET_TABLE + 1;
     } else {
-        return indices.target(i+1+symbol) - TARGET_TABLE;
+        return indices.target(i + 1 + symbol) - TARGET_TABLE;
     }
 }
 
@@ -667,14 +669,14 @@ bool Transducer::has_transitions(const TransitionTableIndex i,
     if (i >= TARGET_TABLE) {
         return (transitions.input_symbol(i - TARGET_TABLE) == symbol);
     } else {
-        return (indices.input_symbol(i+symbol) == symbol);
+        return (indices.input_symbol(i + symbol) == symbol);
     }
 }
 
 bool Transducer::has_epsilons_or_flags(const TransitionTableIndex i)
 {
     if (i >= TARGET_TABLE) {
-        return(transitions.input_symbol(i - TARGET_TABLE) == 0||
+        return(transitions.input_symbol(i - TARGET_TABLE) == 0 ||
                is_flag(transitions.input_symbol(i - TARGET_TABLE)));
     } else {
         return (indices.input_symbol(i) == 0);
@@ -751,7 +753,7 @@ Weight Transducer::final_weight(const TransitionTableIndex i) const
 bool
 Transducer::is_flag(const SymbolNumber symbol)
 {
-    return alphabet.is_flag(symbol); 
+    return alphabet.is_flag(symbol);
 }
 
 bool
@@ -761,7 +763,7 @@ Transducer::is_weighted(void)
 }
 
 
-AnalysisQueue Speller::analyse(char * line, int nbest)
+AnalysisQueue Speller::analyse(char* line, int nbest)
 {
     mode = Lookup;
     if (!init_input(line)) {
@@ -778,7 +780,7 @@ AnalysisQueue Speller::analyse(char * line, int nbest)
         if (next_node.input_state == input.size() &&
             lexicon->is_final(next_node.lexicon_state)) {
             Weight weight = next_node.weight +
-                lexicon->final_weight(next_node.lexicon_state);
+                            lexicon->final_weight(next_node.lexicon_state);
             std::string output = stringify(lexicon->get_key_table(),
                                            next_node.string);
             /* if the result is novel or lower weighted than before, insert it */
@@ -816,8 +818,8 @@ void Speller::build_cache(SymbolNumber first_sym)
             lexicon->is_final(next_node.lexicon_state)) {
             // complete result of length 0 or 1
             Weight weight = next_node.weight +
-                lexicon->final_weight(next_node.lexicon_state) +
-                mutator->final_weight(next_node.mutator_state);
+                            lexicon->final_weight(next_node.lexicon_state) +
+                            mutator->final_weight(next_node.mutator_state);
             std::string string = stringify(lexicon->get_key_table(), next_node.string);
             /* if the correction is novel or better than before, insert it
              */
@@ -836,7 +838,7 @@ void Speller::build_cache(SymbolNumber first_sym)
         if (next_node.input_state == 1) {
             cache[first_sym].nodes.push_back(next_node);
         } else {
-//            std::cerr << "discarded node\n";
+            //            std::cerr << "discarded node\n";
         }
         if (first_sym > 0 && next_node.input_state == 0) {
             consume_input();
@@ -847,7 +849,7 @@ void Speller::build_cache(SymbolNumber first_sym)
     cache[first_sym].empty = false;
 }
 
-CorrectionQueue Speller::correct(char * line, int nbest,
+CorrectionQueue Speller::correct(char* line, int nbest,
                                  Weight maxweight, Weight beam,
                                  float time_cutoff)
 {
@@ -875,27 +877,27 @@ CorrectionQueue Speller::correct(char * line, int nbest,
     }
     if (input.size() <= 1) {
         // get the cached results and we're done
-        StringWeightVector * results;
+        StringWeightVector* results;
         if (input.size() == 0) {
             results = &cache[first_input].results_len_0;
         } else {
             results = &cache[first_input].results_len_1;
         }
-        for(StringWeightVector::const_iterator it = results->begin();
-              // First get the correct weight limit
-              it != results->end(); ++it) {
-                best_suggestion = std::min(best_suggestion, it->second);
-                if (nbest > 0) {
-                    nbest_queue.push(it->second);
-                    if (nbest_queue.size() > nbest) {
-                        nbest_queue.pop();
-                    }
+        for (StringWeightVector::const_iterator it = results->begin();
+             // First get the correct weight limit
+             it != results->end(); ++it) {
+            best_suggestion = std::min(best_suggestion, it->second);
+            if (nbest > 0) {
+                nbest_queue.push(it->second);
+                if (nbest_queue.size() > nbest) {
+                    nbest_queue.pop();
                 }
             }
+        }
         adjust_weight_limits(nbest, beam);
-        for(StringWeightVector::const_iterator it = results->begin();
-              // Then collect the results
-              it != results->end(); ++it) {
+        for (StringWeightVector::const_iterator it = results->begin();
+             // Then collect the results
+             it != results->end(); ++it) {
             if (it->second <= limit && (nbest == 0 || // we either don't have an nbest condition or
                                         (it->second <= nbest_queue.get_highest() && // we're below the worst nbest weight and
                                          correction_queue.size() < nbest &&
@@ -920,15 +922,15 @@ CorrectionQueue Speller::correct(char * line, int nbest,
             ++call_counter;
             if (limit_reached ||
                 (call_counter % 1000000 == 0 &&
-                 (((double)(clock() - start_clock)) / CLOCKS_PER_SEC) > max_time)) {
+                 (((double) (clock() - start_clock)) / CLOCKS_PER_SEC) > max_time)) {
                 limit_reached = true;
                 break;
             }
         }
         /*
-          For depth-first searching, we save the back node now, remove it
-          from the queue and add new nodes to the search at the back.
-        */
+         * For depth-first searching, we save the back node now, remove it
+         * from the queue and add new nodes to the search at the back.
+         */
         next_node = queue.back();
         queue.pop_back();
         adjust_weight_limits(nbest, beam);
@@ -952,8 +954,8 @@ CorrectionQueue Speller::correct(char * line, int nbest,
             if (mutator->is_final(next_node.mutator_state) &&
                 lexicon->is_final(next_node.lexicon_state)) {
                 Weight weight = next_node.weight +
-                    lexicon->final_weight(next_node.lexicon_state) +
-                    mutator->final_weight(next_node.mutator_state);
+                                lexicon->final_weight(next_node.lexicon_state) +
+                                mutator->final_weight(next_node.mutator_state);
                 if (weight > limit) {
                     continue;
                 }
@@ -1049,7 +1051,7 @@ void Speller::adjust_weight_limits(int nbest, Weight beam)
     }
 }
 
-bool Speller::check(char * line)
+bool Speller::check(char* line)
 {
     mode = Check;
     if (!init_input(line)) {
@@ -1072,7 +1074,7 @@ bool Speller::check(char * line)
     return false;
 }
 
-std::string stringify(KeyTable * key_table,
+std::string stringify(KeyTable* key_table,
                       SymbolVector & symbol_vector)
 {
     std::string s;
@@ -1087,10 +1089,10 @@ std::string stringify(KeyTable * key_table,
 
 void Speller::build_alphabet_translator(void)
 {
-    TransducerAlphabet * from = mutator->get_alphabet();
-    TransducerAlphabet * to = lexicon->get_alphabet();
-    KeyTable * from_keys = from->get_key_table();
-    StringSymbolMap * to_symbols = to->get_string_to_symbol();
+    TransducerAlphabet* from = mutator->get_alphabet();
+    TransducerAlphabet* to = lexicon->get_alphabet();
+    KeyTable* from_keys = from->get_key_table();
+    StringSymbolMap* to_symbols = to->get_string_to_symbol();
     alphabet_translator.push_back(0); // zeroth element is always epsilon
     for (SymbolNumber i = 1; i < from_keys->size(); ++i) {
         if (to_symbols->count(from_keys->operator[](i)) != 1) {
@@ -1111,7 +1113,7 @@ void Speller::build_alphabet_translator(void)
     }
 }
 
-bool Speller::init_input(char * line)
+bool Speller::init_input(char* line)
 {
     // Initialize the symbol vector to the tokenization given by encoder.
     // In the case of tokenization failure, valid utf-8 characters
@@ -1120,8 +1122,8 @@ bool Speller::init_input(char * line)
     // empty vector; there is no end marker.
     input.clear();
     SymbolNumber k = NO_SYMBOL;
-    char ** inpointer = &line;
-    char * oldpointer;
+    char** inpointer = &line;
+    char* oldpointer;
 
     while (**inpointer != '\0') {
         oldpointer = *inpointer;
@@ -1146,7 +1148,7 @@ bool Speller::init_input(char * line)
                     lexicon->get_alphabet()->add_symbol(new_symbol_string);
                 }
                 SymbolNumber k_lexicon = lexicon->get_alphabet()->get_string_to_symbol()
-                    ->operator[](new_symbol_string);
+                                         ->operator[](new_symbol_string);
                 lexicon->get_encoder()->read_input_symbol(new_symbol, k_lexicon);
                 if (mutator != NULL) {
                     if (!mutator->get_alphabet()->has_string(new_symbol_string)) {
@@ -1175,21 +1177,19 @@ void Speller::add_symbol_to_alphabet_translator(SymbolNumber to_sym)
 }
 
 } // namespace hfst_ol
-  
+
 char*
 hfst_strndup(const char* s, size_t n)
-  {
-    char* rv = static_cast<char*>(malloc(sizeof(char)*n+1));
-    if (rv == NULL)
-      {
-          return rv;
-      }
-    rv = static_cast<char*>(memcpy(rv, s, n));
-    if (rv == NULL)
-      {
+{
+    char* rv = static_cast<char*>(malloc(sizeof(char) * n + 1));
+    if (rv == NULL) {
         return rv;
-      }
+    }
+    rv = static_cast<char*>(memcpy(rv, s, n));
+    if (rv == NULL) {
+        return rv;
+    }
     rv[n] = '\0';
     return rv;
-  }
-    
+}
+

--- a/ospell.h
+++ b/ospell.h
@@ -35,12 +35,13 @@ typedef std::pair<std::string, std::string> StringPair;
 typedef std::pair<std::string, Weight> StringWeightPair;
 typedef std::vector<StringWeightPair> StringWeightVector;
 typedef std::pair<std::pair<std::string, std::string>, Weight>
-                                                        StringPairWeightPair;
+    StringPairWeightPair;
 typedef std::vector<TreeNode> TreeNodeVector;
 typedef std::map<std::string, Weight> StringWeightMap;
 
 //! Contains low-level processing stuff.
-struct STransition{
+struct STransition
+{
     TransitionTableIndex index; //!< index to transition
     SymbolNumber symbol; //!< symbol of transition
     Weight weight; //!< weight of transition
@@ -48,20 +49,22 @@ struct STransition{
     //!
     //! create transition without weight
     STransition(TransitionTableIndex i,
-                SymbolNumber s):
+                SymbolNumber s) :
         index(i),
         symbol(s),
         weight(0.0)
-        {}
+    {
+    }
 
     //! create transition with weight
     STransition(TransitionTableIndex i,
                 SymbolNumber s,
-                Weight w):
+                Weight w) :
         index(i),
         symbol(s),
         weight(w)
-        {}
+    {
+    }
 
 };
 //! @brief comparison for establishing order for priority queue for suggestions.
@@ -71,21 +74,22 @@ struct STransition{
 //! weight logic of tropical semiring that is present in most weighted
 //! finite-state spell-checking automata.
 class StringWeightComparison
-/* results are reversed by default because greater weights represent
-   worse results - to reverse the reversal, give a true argument*/
+    /* results are reversed by default because greater weights represent
+     * worse results - to reverse the reversal, give a true argument*/
 
 {
     bool reverse;
 public:
     //!
     //! construct a result comparator with ascending or descending weight order
-    StringWeightComparison(bool reverse_result=false):
+    StringWeightComparison(bool reverse_result=false) :
         reverse(reverse_result)
-        {}
-    
+    {
+    }
+
     //!
     //! compare two string weight pairs for weights
-    bool operator() (StringWeightPair lhs, StringWeightPair rhs);
+    bool operator()(StringWeightPair lhs, StringWeightPair rhs);
 };
 
 //! @brief comparison for complex analysis queues
@@ -98,13 +102,14 @@ class StringPairWeightComparison
 public:
     //!
     //! create result comparator with ascending or descending weight order
-    StringPairWeightComparison(bool reverse_result=false):
+    StringPairWeightComparison(bool reverse_result=false) :
         reverse(reverse_result)
-        {}
-    
+    {
+    }
+
     //!
     //! compare two analysis corrections for weights
-    bool operator() (StringPairWeightPair lhs, StringPairWeightPair rhs);
+    bool operator()(StringPairWeightPair lhs, StringPairWeightPair rhs);
 };
 
 typedef std::priority_queue<StringWeightPair,
@@ -120,7 +125,7 @@ typedef std::priority_queue<StringPairWeightPair,
                             std::vector<StringPairWeightPair>,
                             StringPairWeightComparison> AnalysisCorrectionQueue;
 
-struct WeightQueue: public std::list<Weight>
+struct WeightQueue : public std::list<Weight>
 {
     void push(Weight w); // add a new weight
     void pop(void); // delete the biggest weight
@@ -136,42 +141,42 @@ class Transducer
 protected:
     TransducerHeader header; //!< header data
     TransducerAlphabet alphabet; //!< alphabet data
-    KeyTable * keys; //!< key symbol mappings
+    KeyTable* keys; //!< key symbol mappings
     Encoder encoder; //!< encoder to convert the strings
 
     static const TransitionTableIndex START_INDEX = 0; //!< position of first
-  
+
 public:
-    //! 
+    //!
     //! read transducer from file @a f
-    Transducer(FILE * f);
+    Transducer(FILE* f);
     //!
     //! read transducer from raw dara @a data
-    Transducer(char * raw);
+    Transducer(char* raw);
     IndexTable indices; //!< index table
     TransitionTable transitions; //!< transition table
     //!
     //! Deprecated functions for single-tranducer lookup
     //! Speller::analyse() is recommended
     bool initialize_input_vector(SymbolVector & input_vector,
-                                 Encoder * encoder,
-                                 char * line);
-    AnalysisQueue lookup(char * line);
+                                 Encoder* encoder,
+                                 char* line);
+    AnalysisQueue lookup(char* line);
     //!
     //! whether it's final transition in this transducer
     bool final_transition(TransitionTableIndex i);
     //!
-    //! whether it's final index 
+    //! whether it's final index
     bool final_index(TransitionTableIndex i);
     //!
     //! get transducers symbol table mapping
-    KeyTable * get_key_table(void);
+    KeyTable* get_key_table(void);
     //!
     //! find key for string or create it
-    SymbolNumber find_next_key(char ** p);
+    SymbolNumber find_next_key(char** p);
     //!
     //! get encoder for mapping sttrings and symbols
-    Encoder * get_encoder(void);
+    Encoder* get_encoder(void);
     //!
     //! get size of a state
     unsigned int get_state_size(void);
@@ -181,17 +186,17 @@ public:
     SymbolNumber get_identity(void) const;
     //!
     //! get alphabet of automaton
-    TransducerAlphabet * get_alphabet(void);
+    TransducerAlphabet* get_alphabet(void);
     //!
     //! get flag stuff of automaton
-    OperationMap * get_operations(void);
+    OperationMap* get_operations(void);
     //!
     //! follow epsilon transitions from index
     STransition take_epsilons(const TransitionTableIndex i) const;
     //!
     //! follow epsilon transitions and falsg form index
     STransition take_epsilons_and_flags(const TransitionTableIndex i);
-    //! 
+    //!
     //! follow real transitions from index
     STransition take_non_epsilons(const TransitionTableIndex i,
                                   const SymbolNumber symbol) const;
@@ -202,7 +207,7 @@ public:
     //!
     //! get next epsilon inedx
     TransitionTableIndex next_e(const TransitionTableIndex i) const;
-    //! 
+    //!
     //! whether state has any transitions with @a symbol
     bool has_transitions(const TransitionTableIndex i,
                          const SymbolNumber symbol) const;
@@ -212,10 +217,10 @@ public:
     //!
     //! whether state has non-epsilons or non-flags
     bool has_non_epsilons_or_flags(const TransitionTableIndex i);
-    //! 
+    //!
     //! whether it's final
     bool is_final(const TransitionTableIndex i);
-    //! 
+    //!
     //! get final weight
     Weight final_weight(const TransitionTableIndex i) const;
     //!
@@ -232,7 +237,7 @@ public:
 //! Contains low-level processing stuff.
 struct TreeNode
 {
-//    SymbolVector input_string; //<! the current input vector
+    //    SymbolVector input_string; //<! the current input vector
     SymbolVector string; //!< the current output vector
     unsigned int input_state; //!< its input state
     TransitionTableIndex mutator_state; //!< state in error model
@@ -247,25 +252,27 @@ struct TreeNode
              TransitionTableIndex mutator,
              TransitionTableIndex lexicon,
              FlagDiacriticState state,
-             Weight w):
+             Weight w) :
         string(prev_string),
         input_state(i),
         mutator_state(mutator),
         lexicon_state(lexicon),
         flag_state(state),
         weight(w)
-        { }
+    {
+    }
 
-    //! 
+    //!
     //! construct empty node with a starting state for flags
-    TreeNode(FlagDiacriticState start_state): // starting state node
-    string(SymbolVector()),
-    input_state(0),
-    mutator_state(0),
-    lexicon_state(0),
-    flag_state(start_state),
-    weight(0.0)
-        { }
+    TreeNode(FlagDiacriticState start_state) : // starting state node
+        string(SymbolVector()),
+        input_state(0),
+        mutator_state(0),
+        lexicon_state(0),
+        flag_state(start_state),
+        weight(0.0)
+    {
+    }
 
     //!
     //! check if tree node is compatible with flag diacritc
@@ -284,11 +291,11 @@ struct TreeNode
 
     //!
     //! The update functions return updated copies of this state
-     TreeNode update(SymbolNumber output_symbol,
-                     unsigned int next_input,
-                     TransitionTableIndex next_mutator,
-                     TransitionTableIndex next_lexicon,
-                     Weight weight);
+    TreeNode update(SymbolNumber output_symbol,
+                    unsigned int next_input,
+                    TransitionTableIndex next_mutator,
+                    TransitionTableIndex next_lexicon,
+                    Weight weight);
 
     TreeNode update(SymbolNumber output_symbol,
                     TransitionTableIndex next_mutator,
@@ -307,15 +314,16 @@ int nByte_utf8(unsigned char c);
 
 //! May get raised if error model automaton has output characters that are not
 //! present in language model.
-class AlphabetTranslationException: public std::runtime_error
+class AlphabetTranslationException : public std::runtime_error
 { // "what" should hold the first untranslatable symbol
 public:
-    
+
     //!
     //! create alpabet exception with symbol as explanation
-    AlphabetTranslationException(const std::string what):
+    AlphabetTranslationException(const std::string what) :
         std::runtime_error(what)
-        { }
+    {
+    }
 };
 
 //! @brief Basic spell-checking automata pair unit.
@@ -327,8 +335,8 @@ public:
 class Speller
 {
 public:
-    Transducer * mutator; //!< error model
-    Transducer * lexicon; //!< languag model
+    Transducer* mutator; //!< error model
+    Transducer* lexicon; //!< languag model
     SymbolVector input; //!< current input
     TreeNodeQueue queue; //!< current traversal fifo stack
     TreeNode next_node;  //!< current next node
@@ -336,7 +344,7 @@ public:
     Weight best_suggestion; //!< best suggestion so far
     WeightQueue nbest_queue; //!< queue to keep track of current n best results
     SymbolVector alphabet_translator; //!< alphabets in automata
-    OperationMap * operations; //!< flags in it
+    OperationMap* operations; //!< flags in it
     //!< A cache for the result of first symbols
     std::vector<CacheContainer> cache;
     //!< what kind of limiting behaviour we have
@@ -353,10 +361,10 @@ public:
     unsigned long call_counter;
     // A flag to set for when time has been overstepped
     bool limit_reached;
-    
+
     //!
     //! Create a speller object form error model and language automata.
-    Speller(Transducer * mutator_ptr, Transducer * lexicon_ptr);
+    Speller(Transducer* mutator_ptr, Transducer* lexicon_ptr);
     //!
     //! size of states
     SymbolNumber get_state_size(void);
@@ -366,21 +374,21 @@ public:
     void add_symbol_to_alphabet_translator(SymbolNumber to_sym);
     //!
     //! initialize input string
-    bool init_input(char * line);
+    bool init_input(char* line);
     //!
     //! travers epsilons in language model
     void lexicon_epsilons(void);
     bool has_lexicon_epsilons(void) const
-        {
-            return lexicon->has_epsilons_or_flags(next_node.lexicon_state + 1);
-        }
+    {
+        return lexicon->has_epsilons_or_flags(next_node.lexicon_state + 1);
+    }
     //!
     //! traverse epsilons in error modle
     void mutator_epsilons(void);
     bool has_mutator_epsilons(void) const
-        {
-            return mutator->has_transitions(next_node.mutator_state + 1, 0);
-        }
+    {
+        return mutator->has_transitions(next_node.mutator_state + 1, 0);
+    }
     //!
     //! traverse along input
     void consume_input();
@@ -389,31 +397,31 @@ public:
     void lexicon_consume(void);
     void queue_lexicon_arcs(SymbolNumber input,
                             unsigned int mutator_state,
-                            Weight mutator_weight = 0.0,
-                            int input_increment = 0);
+                            Weight mutator_weight=0.0,
+                            int input_increment=0);
     //! @brief Check if the given string is accepted by the speller
     //
     //! foo
-    bool check(char * line);
+    bool check(char* line);
     //! @brief suggest corrections for given string @a line.
     //
     //! The number of corrections given and stored at any given time
-    //! is limited by @a nbest if ≥ 0. 
-    CorrectionQueue correct(char * line, int nbest = 0,
-                            Weight maxweight = -1.0,
-                            Weight beam = -1.0,
-                            float time_cutoff = 0.0);
+    //! is limited by @a nbest if ≥ 0.
+    CorrectionQueue correct(char* line, int nbest=0,
+                            Weight maxweight=-1.0,
+                            Weight beam=-1.0,
+                            float time_cutoff=0.0);
 
     bool is_under_weight_limit(Weight w) const;
     void set_limiting_behaviour(int nbest, Weight maxweight, Weight beam);
     void adjust_weight_limits(int nbest, Weight beam);
-    
+
     //! @brief analyse given string @a line.
     //
     //! If language model is two-tape, give a list of analyses for string.
     //! If not, this should return queue of one result @a line if the
     //! string is in language model and 0 results if it isn't.
-    AnalysisQueue analyse(char * line, int nbest = 0);
+    AnalysisQueue analyse(char* line, int nbest=0);
 
     void build_cache(SymbolNumber first_sym);
     //! @brief Construct a cache entry for @a first_sym..
@@ -429,23 +437,25 @@ struct CacheContainer
     StringWeightVector results_len_1;
     bool empty;
 
-    CacheContainer(void): empty(true) {}
-    
+    CacheContainer(void) : empty(true)
+    {
+    }
+
     void clear(void)
-        {
-            nodes.clear();
-            results_len_0.clear();
-            results_len_1.clear();
-        }
-    
+    {
+        nodes.clear();
+        results_len_0.clear();
+        results_len_1.clear();
+    }
+
 };
 
-std::string stringify(KeyTable * key_table,
+std::string stringify(KeyTable* key_table,
                       SymbolVector & symbol_vector);
 
 } // namespace hfst_ol
 
 // Some platforms lack strndup
 char* hfst_strndup(const char* s, size_t n);
-    
+
 #endif // HFST_OSPELL_OSPELL_H_


### PR DESCRIPTION
The current code styling is inconsistent and suffers from rightward drift fairly significantly in some parts of the codebase. The following patch is a rebase from the config I developed while working on my hfst-ospell fork for use on iOS and Android. I'll probably end up pushing those patches upstream after rebasing them as well.

In the mean time, the proposed patch supplies a `.uncrustify.cfg` file, when used with the `uncrustify` application will apply the styling rules to selected files.

As the codebase would sometimes use `if` statements with a `{` on a new line, and sometimes on the same line, I took a wild stab at which is preferred (same line). Everything else is fairly industry-standard styling.

I wasn't able to find a style-guide or rules that replicate the following style:

```
if (something)
  {
    while (another) 
      {
        doSomething();
      }
  }
```

This patch flattens the braces to a more traditional C++ (K&R-ish) style. If the above example code block's style is the preferred style for the project, then this patch is going to be a dealbreaker for you. 😄 
