### PR TITLE
rename hfst_ol namespace to hfst_ospell to avoid conflicts

### DIFF
--- a/README
+++ b/README
@@ -33,25 +33,25 @@ and link with:
 
 ## Programming examples
 
-The library lives in a namespace called hfst_ol. Pass (weighted!) Transducer
+The library lives in a namespace called hfst_ospell. Pass (weighted!) Transducer
 pointers to the Speller constructor, eg.:
 
     FILE * error_source = fopen(error_filename, "r");
     FILE * lexicon_file = fopen(lexicon_filename, "r");
-    hfst_ol::Transducer * error;
-    hfst_ol::Transducer * lexicon;
+    hfst_ospell::Transducer * error;
+    hfst_ospell::Transducer * lexicon;
     try {
-        error = new hfst_ol::Transducer(error_source);
-        lexicon = new hfst_ol::Transducer(lexicon_file);
-    } catch (hfst_ol::TransducerParsingException& e) {
+        error = new hfst_ospell::Transducer(error_source);
+        lexicon = new hfst_ospell::Transducer(lexicon_file);
+    } catch (hfst_ospell::TransducerParsingException& e) {
             /* problem with transducer file, usually completely
             different type of file - there's no magic number
             in the header to check for this */
         }
-    hfst_ol::Speller * speller;
+    hfst_ospell::Speller * speller;
     try {
-        speller = new hfst_ol::Speller(error, lexicon);
-    } catch (hfst_ol::AlphabetTranslationException& e) {
+        speller = new hfst_ospell::Speller(error, lexicon);
+    } catch (hfst_ospell::AlphabetTranslationException& e) {
         /* problem with translating between the two alphabets */
     }
 
@@ -59,10 +59,10 @@ pointers to the Speller constructor, eg.:
 And use the functions:
 
     // returns true if line is found in lexicon
-    bool hfst_ol::Speller::check(char * line);
+    bool hfst_ospell::Speller::check(char * line);
 
     // CorrectionQueue is a priority queue, sorted by weight
-    hfst_ol::CorrectionQueue hfst_ol::Speller::correct(char * line);
+    hfst_ospell::CorrectionQueue hfst_ospell::Speller::correct(char * line);
 
 
 to communicate with it. See main.cc for a concrete usage example. 

--- a/ZHfstOspeller.cc
+++ b/ZHfstOspeller.cc
@@ -37,7 +37,7 @@ using std::map;
 #include "hfst-ol.h"
 #include "ZHfstOspeller.h"
 
-namespace hfst_ol
+namespace hfst_ospell
   {
 
 #if HAVE_LIBARCHIVE
@@ -475,4 +475,4 @@ ZHfstOspeller::metadata_dump() const
     return metadata_.debug_dump();
 
   }
-} // namespace hfst_ol
+} // namespace hfst_ospell

--- a/ZHfstOspeller.h
+++ b/ZHfstOspeller.h
@@ -41,7 +41,7 @@
 #include "hfst-ol.h"
 #include "ZHfstOspellerXmlMetadata.h"
 
-namespace hfst_ol
+namespace hfst_ospell
   {
     //! @brief ZHfstOspeller class holds one speller contained in one
     //!        zhfst file.
@@ -195,7 +195,7 @@ namespace hfst_ol
           explicit ZHfstTemporaryWritingError(const std::string& message) : ZHfstException(message) {}
     };
 
-  } // namespace hfst_ol
+  } // namespace hfst_ospell
 
 
 #endif // HFST_OSPELL_OSPELLER_SET_H_

--- a/ZHfstOspellerXmlMetadata.cc
+++ b/ZHfstOspellerXmlMetadata.cc
@@ -42,7 +42,7 @@ using std::map;
 #include "ZHfstOspeller.h"
 #include "ZHfstOspellerXmlMetadata.h"
 
-namespace hfst_ol
+namespace hfst_ospell
   {
 
 ZHfstOspellerXmlMetadata::ZHfstOspellerXmlMetadata()
@@ -1034,6 +1034,6 @@ ZHfstOspellerXmlMetadata::debug_dump() const
     return retval;
   }
 
-  } // namespace hfst_ol
+  } // namespace hfst_ospell
 
 

--- a/ZHfstOspellerXmlMetadata.h
+++ b/ZHfstOspellerXmlMetadata.h
@@ -35,7 +35,7 @@ using std::map;
 #include "ospell.h"
 #include "hfst-ol.h"
 
-namespace hfst_ol 
+namespace hfst_ospell 
   {
     //! @brief data type for associating set of translations to languages.
     typedef std::map<std::string,std::string> LanguageVersions;

--- a/hfst-ol.cc
+++ b/hfst-ol.cc
@@ -18,7 +18,7 @@
 #  include <config.h>
 #endif
 
-namespace hfst_ol {
+namespace hfst_ospell {
 
 template <typename T>
 inline T hfst_deref(T* ptr)
@@ -121,7 +121,7 @@ TransducerHeader::read_property(bool& property, FILE* f)
     } else {
         unsigned int prop;
         if (fread(&prop,sizeof(uint32_t),1,f) != 1) {
-            HFST_THROW_MESSAGE(HeaderParsingException,
+            HFSTOSPELL_THROW_MESSAGE(HeaderParsingException,
                                "Header ended unexpectedly\n");
         }
         if (prop == 0)
@@ -168,23 +168,23 @@ void TransducerHeader::skip_hfst3_header(FILE * f)
         } else {
             if (fread(&remaining_header_len,
                       sizeof(remaining_header_len), 1, f) != 1) {
-                HFST_THROW_MESSAGE(HeaderParsingException,
+                HFSTOSPELL_THROW_MESSAGE(HeaderParsingException,
                                    "Found broken HFST3 header\n");
             }
         }
         //std::cerr << "remaining_header_len " << remaining_header_len << std::endl;
         if (getc(f) != '\0') {
-            HFST_THROW_MESSAGE(HeaderParsingException,
+            HFSTOSPELL_THROW_MESSAGE(HeaderParsingException,
                                "Found broken HFST3 header\n");
         }
         char * headervalue = new char[remaining_header_len];
         if (fread(headervalue, remaining_header_len, 1, f) != 1)
         {
-            HFST_THROW_MESSAGE(HeaderParsingException,
+            HFSTOSPELL_THROW_MESSAGE(HeaderParsingException,
                                "HFST3 header ended unexpectedly\n");
         }
         if (headervalue[remaining_header_len - 1] != '\0') {
-            HFST_THROW_MESSAGE(HeaderParsingException,
+            HFSTOSPELL_THROW_MESSAGE(HeaderParsingException,
                                "Found broken HFST3 header\n");
         }
         std::string header_tail(headervalue, remaining_header_len);
@@ -193,7 +193,7 @@ void TransducerHeader::skip_hfst3_header(FILE * f)
             if (header_tail.find("HFST_OL") != type_field + 5 &&
                 header_tail.find("HFST_OLW") != type_field + 5) {
                 delete[] headervalue;
-                HFST_THROW_MESSAGE(
+                HFSTOSPELL_THROW_MESSAGE(
                     TransducerTypeException,
                     "Transducer has incorrect type, should be "
                     "hfst-optimized-lookup\n");
@@ -268,7 +268,7 @@ TransducerHeader::TransducerHeader(FILE* f)
                   sizeof(TransitionTableIndex),1,f) != 1||
             fread(&number_of_transitions,
                   sizeof(TransitionTableIndex),1,f) != 1) {
-            HFST_THROW_MESSAGE(HeaderParsingException,
+            HFSTOSPELL_THROW_MESSAGE(HeaderParsingException,
                                "Header ended unexpectedly\n");
         }
     }
@@ -429,7 +429,7 @@ void TransducerAlphabet::read(FILE * f, SymbolNumber number_of_symbols)
     while ( (byte = fgetc(f)) != 0 ) {
         /* pass over epsilon */
         if (byte == EOF) {
-            HFST_THROW(AlphabetParsingException);
+            HFSTOSPELL_THROW(AlphabetParsingException);
         }
     }
 
@@ -437,7 +437,7 @@ void TransducerAlphabet::read(FILE * f, SymbolNumber number_of_symbols)
         char * sym = line;
         while ( (byte = fgetc(f)) != 0 ) {
             if (byte == EOF) {
-                HFST_THROW(AlphabetParsingException);
+                HFSTOSPELL_THROW(AlphabetParsingException);
             }
             *sym = static_cast<char>(byte);
             ++sym;
@@ -667,7 +667,7 @@ void IndexTable::read(FILE * f,
     size_t table_size = number_of_table_entries*TransitionIndex::SIZE;
     indices = (char*)(malloc(table_size));
     if (fread(indices,table_size, 1, f) != 1) {
-        HFST_THROW(IndexTableReadingException);
+        HFSTOSPELL_THROW(IndexTableReadingException);
     }
     if (is_big_endian()) {
         convert_to_big_endian();
@@ -706,7 +706,7 @@ void TransitionTable::read(FILE * f,
     size_t table_size = number_of_table_entries*Transition::SIZE;
     transitions = (char*)(malloc(table_size));
     if (fread(transitions, table_size, 1, f) != 1) {
-        HFST_THROW(TransitionTableReadingException);
+        HFSTOSPELL_THROW(TransitionTableReadingException);
     }
     if (is_big_endian()) {
         convert_to_big_endian();
@@ -1032,4 +1032,4 @@ SymbolNumber Encoder::find_key(char ** p)
     return s;
 }
 
-} // namespace hfst_ol
+} // namespace hfst_ospell

--- a/hfst-ol.h
+++ b/hfst-ol.h
@@ -34,7 +34,7 @@
 #include <utility>
 #include "ol-exceptions.h"
 
-namespace hfst_ol {
+namespace hfst_ospell {
 
 typedef uint16_t SymbolNumber;
 typedef uint32_t TransitionTableIndex;
@@ -457,6 +457,6 @@ void debug_print(printable p)
     }
 }
 
-} // namespace hfst_ol
+} // namespace hfst_ospell
 
 #endif // HFST_OSPELL_HFST_OL_H_

--- a/main-cicling.cc
+++ b/main-cicling.cc
@@ -140,24 +140,24 @@ int main(int argc, char **argv)
             return 1;
         }
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
-    mutator = new hfst_ol::Transducer(mutator_file);
+    hfst_ospell::Transducer * mutator;
+    hfst_ospell::Transducer * lexicon;
+    mutator = new hfst_ospell::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    lexicon = new hfst_ol::Transducer(lexicon_file);
+    lexicon = new hfst_ospell::Transducer(lexicon_file);
     if (!lexicon->is_weighted()) {
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
     
-    hfst_ol::Speller * speller;
+    hfst_ospell::Speller * speller;
 
     try {
-        speller = new hfst_ol::Speller(mutator, lexicon);
-    } catch (hfst_ol::AlphabetTranslationException& e) {
+        speller = new hfst_ospell::Speller(mutator, lexicon);
+    } catch (hfst_ospell::AlphabetTranslationException& e) {
         std::cerr <<
         "Unable to build speller - symbol " << e.what() << " not "
         "present in lexicon's alphabet\n";
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
         assert(tok != NULL);
         char* context = strdup(tok);
         // unknown += (corr in NWORDS)
-        hfst_ol::CorrectionQueue corrections = speller->correct(mispelt);
+        hfst_ospell::CorrectionQueue corrections = speller->correct(mispelt);
         if (corrections.size() == 0)
           {
             // correction too far

--- a/main-fsmnlp-2012.cc
+++ b/main-fsmnlp-2012.cc
@@ -38,8 +38,8 @@
 #include "ZHfstOspeller.h"
 
 
-using hfst_ol::ZHfstOspeller;
-using hfst_ol::Transducer;
+using hfst_ospell::ZHfstOspeller;
+using hfst_ospell::Transducer;
 
 static bool quiet = false;
 static bool verbose = false;
@@ -98,24 +98,24 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
               << std::endl;
         return EXIT_FAILURE;
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
-    mutator = new hfst_ol::Transducer(mutator_file);
+    hfst_ospell::Transducer * mutator;
+    hfst_ospell::Transducer * lexicon;
+    mutator = new hfst_ospell::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    lexicon = new hfst_ol::Transducer(lexicon_file);
+    lexicon = new hfst_ospell::Transducer(lexicon_file);
     if (!lexicon->is_weighted()) {
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
     
-    hfst_ol::Speller * speller;
+    hfst_ospell::Speller * speller;
 
     try {
-        speller = new hfst_ol::Speller(mutator, lexicon);
-    } catch (hfst_ol::AlphabetTranslationException& e) {
+        speller = new hfst_ospell::Speller(mutator, lexicon);
+    } catch (hfst_ospell::AlphabetTranslationException& e) {
         std::cerr <<
         "Unable to build speller - symbol " << e.what() << " not "
         "present in lexicon's alphabet\n";
@@ -128,7 +128,7 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
         if (speller->check(str)) {
         std::cout << "\"" << str << "\" is in the lexicon\n\n";
         } else {
-        hfst_ol::CorrectionQueue corrections = speller->correct(str);
+        hfst_ospell::CorrectionQueue corrections = speller->correct(str);
         if (corrections.size() > 0) {
             std::cout << "Corrections for \"" << str << "\":\n";
             while (corrections.size() > 0)
@@ -168,39 +168,39 @@ fallback_spell(const char* errmodel_filename1, const char* errmodel_filename2,
               << std::endl;
         return EXIT_FAILURE;
     }
-    hfst_ol::Transducer * mutator1;
-    hfst_ol::Transducer * mutator2;
-    hfst_ol::Transducer * lexicon;
-    mutator1= new hfst_ol::Transducer(mutator_file1);
+    hfst_ospell::Transducer * mutator1;
+    hfst_ospell::Transducer * mutator2;
+    hfst_ospell::Transducer * lexicon;
+    mutator1= new hfst_ospell::Transducer(mutator_file1);
     if (!mutator1->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    mutator2= new hfst_ol::Transducer(mutator_file2);
+    mutator2= new hfst_ospell::Transducer(mutator_file2);
     if (!mutator2->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    lexicon = new hfst_ol::Transducer(lexicon_file);
+    lexicon = new hfst_ospell::Transducer(lexicon_file);
     if (!lexicon->is_weighted()) {
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
     
-    hfst_ol::Speller * speller1;
-    hfst_ol::Speller * speller2;
+    hfst_ospell::Speller * speller1;
+    hfst_ospell::Speller * speller2;
 
     try {
-        speller1 = new hfst_ol::Speller(mutator1, lexicon);
-    } catch (hfst_ol::AlphabetTranslationException& e) {
+        speller1 = new hfst_ospell::Speller(mutator1, lexicon);
+    } catch (hfst_ospell::AlphabetTranslationException& e) {
         std::cerr <<
         "Unable to build speller - symbol " << e.what() << " not "
         "present in lexicon's alphabet\n";
         return EXIT_FAILURE;
     }
     try {
-        speller2 = new hfst_ol::Speller(mutator2, lexicon);
-    } catch (hfst_ol::AlphabetTranslationException& e) {
+        speller2 = new hfst_ospell::Speller(mutator2, lexicon);
+    } catch (hfst_ospell::AlphabetTranslationException& e) {
         std::cerr <<
         "Unable to build speller - symbol " << e.what() << " not "
         "present in lexicon's alphabet\n";
@@ -213,7 +213,7 @@ fallback_spell(const char* errmodel_filename1, const char* errmodel_filename2,
         if (speller1->check(str)) {
         std::cout << "\"" << str << "\" is in the lexicon 1\n\n";
         } else {
-        hfst_ol::CorrectionQueue corrections1 = speller1->correct(str);
+        hfst_ospell::CorrectionQueue corrections1 = speller1->correct(str);
         if (corrections1.size() > 0) {
             std::cout << "Corrections for \"" << str << "\" w/ source 1:\n";
             while (corrections1.size() > 0)
@@ -223,7 +223,7 @@ fallback_spell(const char* errmodel_filename1, const char* errmodel_filename2,
             }
             std::cout << std::endl;
         } else {
-	    hfst_ol::CorrectionQueue corrections2 = speller2->correct(str);
+	    hfst_ospell::CorrectionQueue corrections2 = speller2->correct(str);
 	    if (corrections2.size() > 0) {
 		std::cout << "Corrections for \"" << str << "\" w/ source 2:\n";
 		while (corrections2.size() > 0)
@@ -250,7 +250,7 @@ zhfst_spell(char* zhfst_filename)
     {
       speller.read_zhfst(zhfst_filename);
     }
-  catch (hfst_ol::ZHfstZipReadingError zhzre)
+  catch (hfst_ospell::ZHfstZipReadingError zhzre)
     {
       std::cerr << "cannot read zhfst archive " << zhfst_filename << ":" 
           << std::endl
@@ -258,7 +258,7 @@ zhfst_spell(char* zhfst_filename)
           << "trying to read as legacy automata directory" << std::endl;
       speller.read_legacy(zhfst_filename);
     }
-  catch (hfst_ol::ZHfstLegacyReadingError zhlre)
+  catch (hfst_ospell::ZHfstLegacyReadingError zhlre)
     {
       std::cerr << "cannot read legacy hfst speller dir " << zhfst_filename 
           << ":" << std::endl
@@ -281,7 +281,7 @@ zhfst_spell(char* zhfst_filename)
         if (speller.spell(str)) {
         std::cout << "\"" << str << "\" is in the lexicon\n\n";
         } else {
-        hfst_ol::CorrectionQueue corrections = speller.suggest(str);
+        hfst_ospell::CorrectionQueue corrections = speller.suggest(str);
         if (corrections.size() > 0) {
             std::cout << "Corrections for \"" << str << "\":\n";
             while (corrections.size() > 0)

--- a/main-ispell.cc
+++ b/main-ispell.cc
@@ -38,8 +38,8 @@
 #include "ospell.h"
 #include "ZHfstOspeller.h"
 
-using hfst_ol::ZHfstOspeller;
-using hfst_ol::Transducer;
+using hfst_ospell::ZHfstOspeller;
+using hfst_ospell::Transducer;
 
 //static bool quiet = false;
 static bool verbose = false;
@@ -161,7 +161,7 @@ print_correct(const char* /*s*/)
 
 static
 void
-print_corrections(const char* s, hfst_ol::CorrectionQueue& c)
+print_corrections(const char* s, hfst_ospell::CorrectionQueue& c)
   {
     fprintf(stdout, "& %s %zu %d: ", s, c.size(), 0);
     bool comma = false;
@@ -202,26 +202,26 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
               << std::endl;
         return EXIT_FAILURE;
       }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
-    mutator = new hfst_ol::Transducer(mutator_file);
+    hfst_ospell::Transducer * mutator;
+    hfst_ospell::Transducer * lexicon;
+    mutator = new hfst_ospell::Transducer(mutator_file);
     if (!mutator->is_weighted()) 
       {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
       }
-    lexicon = new hfst_ol::Transducer(lexicon_file);
+    lexicon = new hfst_ospell::Transducer(lexicon_file);
     if (!lexicon->is_weighted()) 
       {
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
       }
-    hfst_ol::Speller * speller;
+    hfst_ospell::Speller * speller;
     try 
       {
-        speller = new hfst_ol::Speller(mutator, lexicon);
+        speller = new hfst_ospell::Speller(mutator, lexicon);
       }
-    catch (hfst_ol::AlphabetTranslationException& e) 
+    catch (hfst_ospell::AlphabetTranslationException& e) 
       {
         std::cerr <<
         "Unable to build speller - symbol " << e.what() << " not "
@@ -248,7 +248,7 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
           }
         else
           {
-            hfst_ol::CorrectionQueue corrections = speller->correct(str, 5);
+            hfst_ospell::CorrectionQueue corrections = speller->correct(str, 5);
             if (corrections.size() > 0) 
               {
                 print_corrections(str, corrections);
@@ -270,13 +270,13 @@ zhfst_spell(char* zhfst_filename, FILE* input)
       {
         speller.read_zhfst(zhfst_filename);
       }
-    catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
+    catch (hfst_ospell::ZHfstMetaDataParsingError zhmdpe)
       {
         std::cerr << "cannot finish reading zhfst archive " << zhfst_filename <<
                    ":" << zhmdpe.what() << "." << std::endl;
         return EXIT_FAILURE;
       }
-    catch (hfst_ol::ZHfstZipReadingError zhzre)
+    catch (hfst_ospell::ZHfstZipReadingError zhzre)
       {
         std::cerr << "cannot read zhfst archive " << zhfst_filename << ":" 
           << zhzre.what() << "." << std::endl
@@ -285,7 +285,7 @@ zhfst_spell(char* zhfst_filename, FILE* input)
           {
             speller.read_legacy(zhfst_filename);
           }
-        catch (hfst_ol::ZHfstLegacyReadingError zhlre)
+        catch (hfst_ospell::ZHfstLegacyReadingError zhlre)
           {
             std::cerr << "cannot fallback to read legacy hfst speller dir " 
               << zhfst_filename 
@@ -322,7 +322,7 @@ zhfst_spell(char* zhfst_filename, FILE* input)
           } 
         else 
           {
-            hfst_ol::CorrectionQueue corrections = speller.suggest(str);
+            hfst_ospell::CorrectionQueue corrections = speller.suggest(str);
             if (corrections.size() > 0)
               {
                 print_corrections(str, corrections);

--- a/main-lrec2013.cc
+++ b/main-lrec2013.cc
@@ -42,8 +42,8 @@
 #include "ospell.h"
 #include "ZHfstOspeller.h"
 
-using hfst_ol::ZHfstOspeller;
-using hfst_ol::Transducer;
+using hfst_ospell::ZHfstOspeller;
+using hfst_ospell::Transducer;
 
 static bool quiet = false;
 static bool verbose = false;
@@ -116,12 +116,12 @@ zhfst_spell(char* zhfst_filename)
       {
         speller.read_zhfst(zhfst_filename);
       }
-   catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
+   catch (hfst_ospell::ZHfstMetaDataParsingError zhmdpe)
      {
        error(EXIT_FAILURE, 0, "error while parsing metadata in %s: %s\n",
              zhfst_filename, zhmdpe.what());
      }
-   catch (hfst_ol::ZHfstZipReadingError zhzre)
+   catch (hfst_ospell::ZHfstZipReadingError zhzre)
      {
        error(EXIT_FAILURE, 0, "error while unzipping %s: %s\n",
              zhfst_filename, zhzre.what());
@@ -212,7 +212,7 @@ zhfst_spell(char* zhfst_filename)
                 fprintf(stdout, "\t%s", str);
               }
           }
-        hfst_ol::CorrectionQueue corrections = speller.suggest(str /*,
+        hfst_ospell::CorrectionQueue corrections = speller.suggest(str /*,
                                                                 max_results */);
         while (corrections.size() > 0)
           {

--- a/main-norvig.cc
+++ b/main-norvig.cc
@@ -140,24 +140,24 @@ int main(int argc, char **argv)
             return 1;
         }
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
-    mutator = new hfst_ol::Transducer(mutator_file);
+    hfst_ospell::Transducer * mutator;
+    hfst_ospell::Transducer * lexicon;
+    mutator = new hfst_ospell::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    lexicon = new hfst_ol::Transducer(lexicon_file);
+    lexicon = new hfst_ospell::Transducer(lexicon_file);
     if (!lexicon->is_weighted()) {
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
     
-    hfst_ol::Speller * speller;
+    hfst_ospell::Speller * speller;
 
     try {
-        speller = new hfst_ol::Speller(mutator, lexicon);
-    } catch (hfst_ol::AlphabetTranslationException& e) {
+        speller = new hfst_ospell::Speller(mutator, lexicon);
+    } catch (hfst_ospell::AlphabetTranslationException& e) {
         std::cerr <<
         "Unable to build speller - symbol " << e.what() << " not "
         "present in lexicon's alphabet\n";
@@ -208,7 +208,7 @@ int main(int argc, char **argv)
         else
           {
 
-            hfst_ol::CorrectionQueue corrections = speller->correct(mispelt);
+            hfst_ospell::CorrectionQueue corrections = speller->correct(mispelt);
             if (corrections.size() == 0)
               {
                 bad++;

--- a/main-survey.cc
+++ b/main-survey.cc
@@ -37,8 +37,8 @@
 #include "ospell.h"
 #include "ZHfstOspeller.h"
 
-using hfst_ol::ZHfstOspeller;
-using hfst_ol::Transducer;
+using hfst_ospell::ZHfstOspeller;
+using hfst_ospell::Transducer;
 
 static bool quiet = false;
 static bool verbose = false;
@@ -120,24 +120,24 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
               << std::endl;
         return EXIT_FAILURE;
     }
-    hfst_ol::Transducer * mutator;
-    hfst_ol::Transducer * lexicon;
-    mutator = new hfst_ol::Transducer(mutator_file);
+    hfst_ospell::Transducer * mutator;
+    hfst_ospell::Transducer * lexicon;
+    mutator = new hfst_ospell::Transducer(mutator_file);
     if (!mutator->is_weighted()) {
         std::cerr << "Error source was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
-    lexicon = new hfst_ol::Transducer(lexicon_file);
+    lexicon = new hfst_ospell::Transducer(lexicon_file);
     if (!lexicon->is_weighted()) {
         std::cerr << "Lexicon was unweighted, exiting\n\n";
         return EXIT_FAILURE;
     }
     
-    hfst_ol::Speller * speller;
+    hfst_ospell::Speller * speller;
 
     try {
-        speller = new hfst_ol::Speller(mutator, lexicon);
-    } catch (hfst_ol::AlphabetTranslationException& e) {
+        speller = new hfst_ospell::Speller(mutator, lexicon);
+    } catch (hfst_ospell::AlphabetTranslationException& e) {
         std::cerr <<
         "Unable to build speller - symbol " << e.what() << " not "
         "present in lexicon's alphabet\n";
@@ -215,7 +215,7 @@ legacy_spell(const char* errmodel_filename, const char* acceptor_filename)
                 fprintf(stdout, "\t%s\n", str);
               }
           }
-        hfst_ol::CorrectionQueue corrections = speller->correct(str /*,
+        hfst_ospell::CorrectionQueue corrections = speller->correct(str /*,
                                                                 max_results */);
         while (corrections.size() > 0)
           {

--- a/main.cc
+++ b/main.cc
@@ -40,15 +40,15 @@
 #include "ospell.h"
 #include "ZHfstOspeller.h"
 
-using hfst_ol::ZHfstOspeller;
-using hfst_ol::Transducer;
+using hfst_ospell::ZHfstOspeller;
+using hfst_ospell::Transducer;
 
 static bool quiet = false;
 static bool verbose = false;
 static bool analyse = false;
 static unsigned long suggs = 0;
-static hfst_ol::Weight max_weight = -1.0;
-static hfst_ol::Weight beam = -1.0;
+static hfst_ospell::Weight max_weight = -1.0;
+static hfst_ospell::Weight beam = -1.0;
 static float time_cutoff = 0.0;
 static std::string error_model_filename = "";
 static std::string lexicon_filename = "";
@@ -164,7 +164,7 @@ bool print_short_help(void)
 void
 do_suggest(ZHfstOspeller& speller, const std::string& str)
   {
-    hfst_ol::CorrectionQueue corrections = speller.suggest(str);
+    hfst_ospell::CorrectionQueue corrections = speller.suggest(str);
     if (corrections.size() > 0) 
     {
         hfst_fprintf(stdout, "Corrections for \"%s\":\n", str.c_str());
@@ -173,7 +173,7 @@ do_suggest(ZHfstOspeller& speller, const std::string& str)
             const std::string& corr = corrections.top().first;
             if (analyse)
               {
-                hfst_ol::AnalysisQueue anals = speller.analyse(corr, true);
+                hfst_ospell::AnalysisQueue anals = speller.analyse(corr, true);
                 bool all_discarded = true;
                 while (anals.size() > 0)
                   {
@@ -229,7 +229,7 @@ do_spell(ZHfstOspeller& speller, const std::string& str)
         if (analyse)
           {
             hfst_fprintf(stdout, "analysing:\n");
-            hfst_ol::AnalysisQueue anals = speller.analyse(str, false);
+            hfst_ospell::AnalysisQueue anals = speller.analyse(str, false);
             bool all_no_spell = true;
             while (anals.size() > 0)
               {
@@ -281,7 +281,7 @@ zhfst_spell(char* zhfst_filename)
     {
       speller.read_zhfst(zhfst_filename);
     }
-  catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe)
+  catch (hfst_ospell::ZHfstMetaDataParsingError zhmdpe)
     {
       hfst_fprintf(stderr, "cannot finish reading zhfst archive %s:\n%s.\n", 
                          zhfst_filename, zhmdpe.what());
@@ -289,7 +289,7 @@ zhfst_spell(char* zhfst_filename)
       //             ":\n" << zhmdpe.what() << "." << std::endl;
       return EXIT_FAILURE;
     }
-  catch (hfst_ol::ZHfstZipReadingError zhzre)
+  catch (hfst_ospell::ZHfstZipReadingError zhzre)
     {
       //std::cerr << "cannot read zhfst archive " << zhfst_filename << ":\n" 
       //    << zhzre.what() << "." << std::endl
@@ -300,7 +300,7 @@ zhfst_spell(char* zhfst_filename)
                          zhfst_filename, zhzre.what());
       return EXIT_FAILURE;
     }
-  catch (hfst_ol::ZHfstXmlParsingError zhxpe)
+  catch (hfst_ospell::ZHfstXmlParsingError zhxpe)
     {
       //std::cerr << "Cannot finish reading index.xml from " 
       //  << zhfst_filename << ":" << std::endl
@@ -378,7 +378,7 @@ zhfst_spell(char* zhfst_filename)
 }
 
 int
-    legacy_spell(hfst_ol::Speller * s)
+    legacy_spell(hfst_ospell::Speller * s)
 {
       ZHfstOspeller speller;
       speller.inject_speller(s);
@@ -600,9 +600,9 @@ int main(int argc, char **argv)
           }
           FILE * err_file = fopen(error_model_filename.c_str(), "r");
           FILE * lex_file = fopen(lexicon_filename.c_str(), "r");
-          hfst_ol::Transducer err(err_file);
-          hfst_ol::Transducer lex(lex_file);
-          hfst_ol::Speller * s = new hfst_ol::Speller(&err, &lex);
+          hfst_ospell::Transducer err(err_file);
+          hfst_ospell::Transducer lex(lex_file);
+          hfst_ospell::Speller * s = new hfst_ospell::Speller(&err, &lex);
           return legacy_spell(s);
       }
     return EXIT_SUCCESS;

--- a/office.cc
+++ b/office.cc
@@ -51,8 +51,8 @@
 
 #include "ZHfstOspeller.h"
 
-using hfst_ol::ZHfstOspeller;
-using hfst_ol::Transducer;
+using hfst_ospell::ZHfstOspeller;
+using hfst_ospell::Transducer;
 
 typedef std::map<UnicodeString,bool> valid_words_t;
 valid_words_t valid_words;
@@ -74,7 +74,7 @@ bool find_alternatives(ZHfstOspeller& speller, size_t suggs) {
 	for (size_t k=1 ; k <= cw ; ++k) {
 		buffer.clear();
 		words[cw-k].buffer.toUTF8String(buffer);
-		hfst_ol::CorrectionQueue corrections = speller.suggest(buffer);
+		hfst_ospell::CorrectionQueue corrections = speller.suggest(buffer);
 
 		if (corrections.size() == 0) {
 			continue;
@@ -277,15 +277,15 @@ int zhfst_spell(const char* zhfst_filename) {
 		speller.read_zhfst(zhfst_filename);
 		speller.set_time_cutoff(6.0);
 	}
-	catch (hfst_ol::ZHfstMetaDataParsingError zhmdpe) {
+	catch (hfst_ospell::ZHfstMetaDataParsingError zhmdpe) {
 		fprintf(stderr, "cannot finish reading zhfst archive %s:\n%s.\n", zhfst_filename, zhmdpe.what());
 		return EXIT_FAILURE;
 	}
-	catch (hfst_ol::ZHfstZipReadingError zhzre) {
+	catch (hfst_ospell::ZHfstZipReadingError zhzre) {
 		fprintf(stderr, "cannot read zhfst archive %s:\n%s.\n", zhfst_filename, zhzre.what());
 		return EXIT_FAILURE;
 	}
-	catch (hfst_ol::ZHfstXmlParsingError zhxpe) {
+	catch (hfst_ospell::ZHfstXmlParsingError zhxpe) {
 		fprintf(stderr, "Cannot finish reading index.xml from %s:\n%s.\n", zhfst_filename, zhxpe.what());
 		return EXIT_FAILURE;
 	}

--- a/ol-exceptions.h
+++ b/ol-exceptions.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <sstream>
 
-namespace hfst_ol
+namespace hfst_ospell
 {
 
 // This structure is inherited from for each exception. Taken from HFST library
@@ -51,12 +51,12 @@ struct OspellException
 
 // These macros are used instead of the normal exception facilities.
 
-#define HFST_THROW(E) throw E(#E,__FILE__,__LINE__)
+#define HFSTOSPELL_THROW(E) throw E(#E,__FILE__,__LINE__)
 
-#define HFST_THROW_MESSAGE(E,M) throw E(std::string(#E)+": "+std::string(M)\
+#define HFSTOSPELL_THROW_MESSAGE(E,M) throw E(std::string(#E)+": "+std::string(M)\
                         ,__FILE__,__LINE__)
 
-#define HFST_EXCEPTION_CHILD_DECLARATION(CHILD) \
+#define HFSTOSPELL_EXCEPTION_CHILD_DECLARATION(CHILD) \
     struct CHILD : public OspellException \
     { CHILD(const std::string &name,const std::string &file,size_t line):\
     OspellException(name,file,line) {}} 
@@ -70,16 +70,16 @@ struct OspellException
 
 // Now the exceptions themselves
 
-HFST_EXCEPTION_CHILD_DECLARATION(HeaderParsingException);
+HFSTOSPELL_EXCEPTION_CHILD_DECLARATION(HeaderParsingException);
 
-HFST_EXCEPTION_CHILD_DECLARATION(AlphabetParsingException);
+HFSTOSPELL_EXCEPTION_CHILD_DECLARATION(AlphabetParsingException);
 
-HFST_EXCEPTION_CHILD_DECLARATION(IndexTableReadingException);
+HFSTOSPELL_EXCEPTION_CHILD_DECLARATION(IndexTableReadingException);
 
-HFST_EXCEPTION_CHILD_DECLARATION(TransitionTableReadingException);
+HFSTOSPELL_EXCEPTION_CHILD_DECLARATION(TransitionTableReadingException);
 
-HFST_EXCEPTION_CHILD_DECLARATION(UnweightedSpellerException);
+HFSTOSPELL_EXCEPTION_CHILD_DECLARATION(UnweightedSpellerException);
 
-HFST_EXCEPTION_CHILD_DECLARATION(TransducerTypeException);
+HFSTOSPELL_EXCEPTION_CHILD_DECLARATION(TransducerTypeException);
 } // namespace
 #endif // _OL_EXCEPTIONS_H

--- a/ospell.cc
+++ b/ospell.cc
@@ -18,7 +18,7 @@
 
 #include "ospell.h"
 
-namespace hfst_ol {
+namespace hfst_ospell {
 
 int nByte_utf8(unsigned char c)
 {
@@ -1200,7 +1200,7 @@ void Speller::add_symbol_to_alphabet_translator(SymbolNumber to_sym)
     alphabet_translator.push_back(to_sym);
 }
 
-} // namespace hfst_ol
+} // namespace hfst_ospell
   
 char*
 hfst_strndup(const char* s, size_t n)

--- a/ospell.h
+++ b/ospell.h
@@ -26,7 +26,7 @@
 #include <ctime>
 #include "hfst-ol.h"
 
-namespace hfst_ol {
+namespace hfst_ospell {
 
 //! Internal class for transition processing.
 
@@ -506,7 +506,7 @@ std::string stringify(KeyTable * key_table,
 std::vector<std::string> symbolify(KeyTable * key_table,
                                    SymbolVector & symbol_vector);
 
-} // namespace hfst_ol
+} // namespace hfst_ospell
 
 // Some platforms lack strndup
 char* hfst_strndup(const char* s, size_t n);


### PR DESCRIPTION
also HFST_THROW → HFSTOSPELL_THROW etc. since macro-replacement
happens before namespacing

fixes #34 - duplicated code from hfst shares namespace with hfst

-----

I guess this needs a version bump too – what number increases this time?