### PR TITLE
Stop hfst-ospell-office from crashing

### DIFF
--- a/office.cc
+++ b/office.cc
@@ -115,7 +115,13 @@ bool find_alternatives(ZHfstOspeller& speller, size_t suggs) {
 				++i;
 			}
 			outputs.insert(buffer);
-			corrections.pop();
+
+            // hack, stops hfst-ospell-office from crashing
+            if (corrections.size() == 0) {
+                break;
+            } else {
+                corrections.pop();
+            }
 		}
 		std::cout << std::endl;
 		return true;


### PR DESCRIPTION
This is just a stop gap fix, there are probably better ways of solving this problem.

When issuing
echo "10 Sámedigg"|/usr/bin/hfst-ospell-office /usr/share/voikko/3/smj.zhfst
without this change, hfst-ospell-office crashes with the message:

free(): invalid pointer: 0x00007fca750d6b98 ***

With this change the answer is:
echo "10 Sámedigg"| ~/.local/bin/hfst-ospell-office /usr/share/voikko/3/smj.zhfst
@@ hfst-ospell-office is alive
&       Sámedigge       Sámediggáj              Sámediggen      Sáme-
digge      Sámedigge-

I use the nightly apertium repo.
smj.zhfst is from giella-smj 0.0.20110617~r160678-1~sid1
The original hfst-ospell-office is from hfst-ospell 0.5.0~r356-0ubuntu1~xenial1