### PR TITLE
C++14 (C++1y) should be the highest supported standard.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,14 +149,10 @@ AC_CHECK_FUNCS([strndup error])
 
 # Checks for highest supported C++ standard
 AC_LANG(C++)
-AX_CHECK_COMPILE_FLAG([-std=c++17], [CXXFLAGS="$CXXFLAGS -std=c++17"], [
- AX_CHECK_COMPILE_FLAG([-std=c++1z], [CXXFLAGS="$CXXFLAGS -std=c++1z"], [
-  AX_CHECK_COMPILE_FLAG([-std=c++14], [CXXFLAGS="$CXXFLAGS -std=c++14"], [
-   AX_CHECK_COMPILE_FLAG([-std=c++1y], [CXXFLAGS="$CXXFLAGS -std=c++1y"], [
-    AX_CHECK_COMPILE_FLAG([-std=c++11], [CXXFLAGS="$CXXFLAGS -std=c++11"], [
-     AC_MSG_ERROR([could not enable C++11 or newer])
-    ])
-   ])
+AX_CHECK_COMPILE_FLAG([-std=c++14], [CXXFLAGS="$CXXFLAGS -std=c++14"], [
+ AX_CHECK_COMPILE_FLAG([-std=c++1y], [CXXFLAGS="$CXXFLAGS -std=c++1y"], [
+  AX_CHECK_COMPILE_FLAG([-std=c++11], [CXXFLAGS="$CXXFLAGS -std=c++11"], [
+   AC_MSG_ERROR([could not enable C++11 or newer])
   ])
  ])
 ])


### PR DESCRIPTION
`hfst-ospell` currently requires `libxml++2`, `libxml++2` uses `std::auto_ptr` which was deprecated since C++11 and has been removed as of C++17.