### PR TITLE
Fix a typo in wide string conversion function (#49).

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -61,7 +61,7 @@ static bool suggest_reals = false;
 #ifdef WINDOWS
 static std::string wide_string_to_string(const std::wstring & wstr)
 {
-  int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)§wstr.size(), NULL, 0, NULL, NULL);
+  int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
   std::string str( size_needed, 0 );
   WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &str[0], size_needed, NULL, NULL);
   return str;


### PR DESCRIPTION
Revert a hunk from:
04e4843e4c66beb61b756f3ceb2ac94628142185.