### PR TITLE
Fix loading from memory on sparc64 (Fix #43)

### DIFF
--- a/hfst-ol.cc
+++ b/hfst-ol.cc
@@ -59,9 +59,9 @@ uint16_t read_uint16_flipping_endianness(FILE * f)
 uint16_t read_uint16_flipping_endianness(char * raw)
 {
     uint16_t result = 0;
-    result |= *(raw + 1);
+    result |= static_cast<uint8_t>(*(raw + 1));
     result <<= 8;
-    result |= *raw;
+    result |= static_cast<uint8_t>(*raw);
     return result;
 }
 
@@ -85,13 +85,13 @@ uint32_t read_uint32_flipping_endianness(FILE * f)
 uint32_t read_uint32_flipping_endianness(char * raw)
 {
     uint32_t result = 0;
-    result |= *(raw + 3);
+    result |= static_cast<uint8_t>(*(raw + 3));
     result <<= 8;
-    result |= *(raw + 2);
+    result |= static_cast<uint8_t>(*(raw + 2));
     result <<= 8;
-    result |= *(raw + 1);
+    result |= static_cast<uint8_t>(*(raw + 1));
     result <<= 8;
-    result |= *raw;
+    result |= static_cast<uint8_t>(*raw);
     return result;
 }
 


### PR DESCRIPTION
This platform is big-endian (requires byte flipping) and has a signed `char` type. Prevent sign-expansion by casting the signed character type to `uint8_t`.

This has been verified to fix the test failure reported in #43